### PR TITLE
RasterBand to Ndarray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ libc = "0.2"
 geo = "0.6"
 gdal-sys = { path = "gdal-sys", version = "0.1"}
 num-traits = "0.1"
+ndarray = "0.11.1"
+num = "0.1.41"
+byteorder = "1.2.1"
 
 [workspace]
 members = ["gdal-sys"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,9 +7,14 @@ error_chain! {
     foreign_links {
         FfiNulError(::std::ffi::NulError);
         StrUtf8Error(::std::str::Utf8Error);
+        NdarrayShapeError(::ndarray::ShapeError);
     }
 
     errors {
+        ConversionError {
+            description("GDAL gdal type to number type conversion error")
+            display("GDAL gdal type to number type conversion error")
+        }
         CplError(class: CPLErr, number: c_int, msg: String) {
             description("GDAL internal error")
             display("CPL error class: '{:?}', error number: '{}', error msg: '{}'", class, number, msg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ extern crate libc;
 extern crate geo;
 extern crate gdal_sys;
 extern crate num_traits;
+extern crate ndarray;
+extern crate num;
+extern crate byteorder;
 
 #[macro_use]
 extern crate error_chain;

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -4,11 +4,12 @@ pub use raster::dataset::{Dataset, Buffer, ByteBuffer};
 pub use raster::driver::Driver;
 pub use raster::warp::reproject;
 pub use raster::rasterband::{RasterBand};
+pub use raster::types::GdalType;
 
 pub use gdal_sys::gdal_enums;
 pub use gdal_sys::cpl_error::{CPLErr};
 
-mod types;
+pub mod types;
 pub mod dataset;
 pub mod driver;
 pub mod warp;

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -185,8 +185,9 @@ impl<'a> MajorObject for RasterBand<'a> {
 
 impl<'a> Metadata for RasterBand<'a> {}
 
-
-/// Read a rasterband into an ndarray. band should be greater than 0
+/// # Read To Array
+/// A helper function that takes a raster band as input. It will
+/// read the rasterband into an ndarray.
 fn read_to_array<T: 'static + Copy + FromPrimitive>(rband: &RasterBand) -> Result<Array2<T>> {
     // get the data type of the dataset
     let gt: GDALDataType = rband.band_type();
@@ -209,7 +210,8 @@ fn read_to_array<T: 'static + Copy + FromPrimitive>(rband: &RasterBand) -> Resul
 }
 
 /// # Extract
-/// A helper function that extracts data from a ByteBuffer.
+/// A helper function that extracts data from a ByteBuffer. It uses the byteorder
+/// crate to read the correct size words from the bytes of the actual raster.
 fn extract<T: 'static + Copy + FromPrimitive>(bytes: Vec<u8>) -> Result<Vec<T>> {
     // wrap the bytes in a cursor
     let mut cursor = Cursor::new(bytes);

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -93,8 +93,7 @@ impl <'a> RasterBand<'a> {
     }
 
     /// Read a full 'Dataset' as an 'ndarray::Array2<T>'.
-    /// # Arguments
-    /// * band_index - the band_index
+    /// 'U' is the primitive you want the data elements of the result 'Array2' to be returned in.
     pub fn read_band_as_array<U: 'static + Copy + FromPrimitive>(&self) -> Result<Array2<U>> {
         read_to_array::<U>(&self)
     }


### PR DESCRIPTION
I added a few functions mostly to RasterBand to support a read_band_as_array method on the RasterBand API. The user must still pass read_band_as_array a type 'U' argument that will return an ndarray::Array2<U> after unwrapping the result. I do not know how to handle the C types on the GDALDataType. I also added a few libraries to support this effort and extended the errors.