### PR TITLE
Add method to set no data values for raster bands

### DIFF
--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -125,6 +125,14 @@ impl <'a> RasterBand<'a> {
         None
     }
 
+    pub fn set_no_data_value(&self, no_data: f64) -> Result<()> {
+        let rv = unsafe { gdal_sys::GDALSetRasterNoDataValue(self.c_rasterband, no_data) };
+        if rv != CPLErr::CE_None {
+            Err(_last_cpl_err(rv))?;
+        }
+        Ok(())
+    }
+
     pub fn scale(&self) ->Option<f64> {
         let mut pb_success = 1;
         let scale = unsafe { gdal_sys::GDALGetRasterScale(self.c_rasterband, &mut pb_success) };

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -255,6 +255,16 @@ fn test_get_no_data_value() {
 }
 
 #[test]
+fn test_set_no_data_value() {
+    let driver = Driver::get("MEM").unwrap();
+    let dataset = driver.create("", 20, 10, 1).unwrap();
+    let rasterband = dataset.rasterband(1).unwrap();
+    assert_eq!(rasterband.no_data_value(), None);
+    assert!(rasterband.set_no_data_value(3.14).is_ok());
+    assert_eq!(rasterband.no_data_value(), Some(3.14));
+}
+
+#[test]
 fn test_get_scale() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
     let rasterband = dataset.rasterband(1).unwrap();


### PR DESCRIPTION
Currently you can retrieve a no data value for a raster, but there doesn't exist a method to set it. Thought this might be useful for someone else other than myself.