### PR TITLE
Bump geo-types to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bindgen = ["gdal-sys/bindgen"]
 failure = "0.1"
 failure_derive = "0.1"
 libc = "0.2"
-geo-types = "0.1"
+geo-types = "0.3"
 # gdal-sys = { path = "gdal-sys", version = "0.2"}
 gdal-sys = "0.2"
 num-traits = "0.2"

--- a/src/vector/gdal_to_geo.rs
+++ b/src/vector/gdal_to_geo.rs
@@ -33,7 +33,7 @@ impl From<Geometry> for geo_types::Geometry<f64> {
             OGRwkbGeometryType::wkbLineString => {
                 let coords = geo.get_point_vec()
                     .iter()
-                    .map(|&(x, y, _)| geo_types::Point(geo_types::Coordinate { x, y }))
+                    .map(|&(x, y, _)| geo_types::Coordinate { x, y })
                     .collect();
                 geo_types::Geometry::LineString(geo_types::LineString(coords))
             }

--- a/src/vector/geo_to_gdal.rs
+++ b/src/vector/geo_to_gdal.rs
@@ -27,7 +27,7 @@ impl <T> ToGdal for geo_types::MultiPoint<T> where T: Float {
 fn geometry_with_points<T>(wkb_type: OGRwkbGeometryType::Type, points: &geo_types::LineString<T>) -> Result<Geometry> where T: Float {
     let mut geom = Geometry::empty(wkb_type)?;
     let &geo_types::LineString(ref linestring) = points;
-    for (i, &geo_types::Point(coordinate)) in linestring.iter().enumerate() {
+    for (i, &coordinate) in linestring.iter().enumerate() {
         geom.set_point_2d(i, (coordinate.x.to_f64().ok_or(ErrorKind::CastToF64Error)?, coordinate.y.to_f64().ok_or(ErrorKind::CastToF64Error)?));
     }
     Ok(geom)
@@ -36,8 +36,8 @@ fn geometry_with_points<T>(wkb_type: OGRwkbGeometryType::Type, points: &geo_type
 impl <T> ToGdal for geo_types::Line<T> where T: Float {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbLineString)?;
-        geom.set_point_2d(0, (self.start.x().to_f64().ok_or(ErrorKind::CastToF64Error)?, self.start.y().to_f64().ok_or(ErrorKind::CastToF64Error)?));
-        geom.set_point_2d(1, (self.end.x().to_f64().ok_or(ErrorKind::CastToF64Error)?, self.end.y().to_f64().ok_or(ErrorKind::CastToF64Error)?));
+        geom.set_point_2d(0, (self.start.x.to_f64().ok_or(ErrorKind::CastToF64Error)?, self.start.y.to_f64().ok_or(ErrorKind::CastToF64Error)?));
+        geom.set_point_2d(1, (self.end.x.to_f64().ok_or(ErrorKind::CastToF64Error)?, self.end.y.to_f64().ok_or(ErrorKind::CastToF64Error)?));
         Ok(geom)
     }
 }

--- a/src/vector/tests/convert_geo.rs
+++ b/src/vector/tests/convert_geo.rs
@@ -35,9 +35,9 @@ fn test_import_export_multipoint() {
 fn test_import_export_linestring() {
     let wkt = "LINESTRING (0 0,0 1,1 2)";
     let coord = vec![
-        geo_types::Point(geo_types::Coordinate { x: 0., y: 0. }),
-        geo_types::Point(geo_types::Coordinate { x: 0., y: 1. }),
-        geo_types::Point(geo_types::Coordinate { x: 1., y: 2. }),
+        geo_types::Coordinate { x: 0., y: 0. },
+        geo_types::Coordinate { x: 0., y: 1. },
+        geo_types::Coordinate { x: 1., y: 2. },
     ];
     let geo = geo_types::Geometry::LineString(geo_types::LineString(coord));
 
@@ -53,14 +53,14 @@ fn test_import_export_multilinestring() {
     let wkt = "MULTILINESTRING ((0 0,0 1,1 2),(3 3,3 4,4 5))";
     let strings = vec![
         geo_types::LineString(vec![
-            geo_types::Point(geo_types::Coordinate { x: 0., y: 0. }),
-            geo_types::Point(geo_types::Coordinate { x: 0., y: 1. }),
-            geo_types::Point(geo_types::Coordinate { x: 1., y: 2. }),
+            geo_types::Coordinate { x: 0., y: 0. },
+            geo_types::Coordinate { x: 0., y: 1. },
+            geo_types::Coordinate { x: 1., y: 2. },
         ]),
         geo_types::LineString(vec![
-            geo_types::Point(geo_types::Coordinate { x: 3., y: 3. }),
-            geo_types::Point(geo_types::Coordinate { x: 3., y: 4. }),
-            geo_types::Point(geo_types::Coordinate { x: 4., y: 5. }),
+            geo_types::Coordinate { x: 3., y: 3. },
+            geo_types::Coordinate { x: 3., y: 4. },
+            geo_types::Coordinate { x: 4., y: 5. },
         ]),
     ];
     let geo = geo_types::Geometry::MultiLineString(geo_types::MultiLineString(strings));
@@ -74,26 +74,26 @@ fn test_import_export_multilinestring() {
 
 fn square(x0: isize, y0: isize, x1: isize, y1: isize) -> geo_types::LineString<f64> {
     geo_types::LineString(vec![
-        geo_types::Point(geo_types::Coordinate {
+        geo_types::Coordinate {
             x: x0 as f64,
             y: y0 as f64,
-        }),
-        geo_types::Point(geo_types::Coordinate {
+        },
+        geo_types::Coordinate {
             x: x0 as f64,
             y: y1 as f64,
-        }),
-        geo_types::Point(geo_types::Coordinate {
+        },
+        geo_types::Coordinate {
             x: x1 as f64,
             y: y1 as f64,
-        }),
-        geo_types::Point(geo_types::Coordinate {
+        },
+        geo_types::Coordinate {
             x: x1 as f64,
             y: y0 as f64,
-        }),
-        geo_types::Point(geo_types::Coordinate {
+        },
+        geo_types::Coordinate {
             x: x0 as f64,
             y: y0 as f64,
-        }),
+        },
     ])
 }
 
@@ -148,9 +148,9 @@ fn test_import_export_geometrycollection() {
     let coord = geo_types::Coordinate { x: 1., y: 2. };
     let point = geo_types::Geometry::Point(geo_types::Point(coord));
     let coords = vec![
-        geo_types::Point(geo_types::Coordinate { x: 0., y: 0. }),
-        geo_types::Point(geo_types::Coordinate { x: 0., y: 1. }),
-        geo_types::Point(geo_types::Coordinate { x: 1., y: 2. }),
+        geo_types::Coordinate { x: 0., y: 0. },
+        geo_types::Coordinate { x: 0., y: 1. },
+        geo_types::Coordinate { x: 1., y: 2. },
     ];
     let linestring = geo_types::Geometry::LineString(geo_types::LineString(coords));
     let collection = geo_types::GeometryCollection(vec![point, linestring]);


### PR DESCRIPTION
So that conversions between `gdal` & `geo-types` geometries are implemented for the latest release of `geo-types`.