### PR TITLE
Make GdalType trait public

### DIFF
--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -5,7 +5,7 @@ pub use raster::driver::Driver;
 pub use raster::warp::reproject;
 pub use raster::rasterband::{RasterBand};
 
-mod types;
+pub mod types;
 pub mod dataset;
 pub mod driver;
 pub mod warp;


### PR DESCRIPTION
This makes the `GdalType` trait public, allowing user code to use it as a type bound. It resolves #48.

I'm a bit new to Rust, so if this is not the right tack please let me know!

cc @jdroenner 