### PR TITLE
read/write support for date und datetime fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://georust.github.io/gdal/"
 bindgen = ["gdal-sys/bindgen"]
 gdal_2_2 = ["gdal-sys/min_gdal_version_2_2"]
 array = ["ndarray"]
+datetime = ["chrono"]
 
 [dependencies]
 failure = "0.1"
@@ -24,7 +25,7 @@ geo-types = "0.4"
 gdal-sys = "0.2"
 num-traits = "0.2"
 ndarray = {version = "0.12.1", optional = true }
-chrono = "0.4"
+chrono = { version = "0.4", optional = true }
 
 [workspace]
 members = ["gdal-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ geo-types = "0.4"
 gdal-sys = "0.2"
 num-traits = "0.2"
 ndarray = {version = "0.12.1", optional = true }
+chrono = "0.4"
 
 [workspace]
 members = ["gdal-sys"]

--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -1,14 +1,20 @@
+
 extern crate gdal;
+#[cfg(feature = "datetime")]
 extern crate chrono;
 
 use std::path::Path;
 use gdal::errors::Error;
 use gdal::vector::*;
 use std::fs;
+#[cfg(feature = "datetime")]
 use chrono::Duration;
 use std::ops::Add;
 
+#[cfg(feature = "datetime")]
 fn run() -> Result<(), Error> {
+    println!("gdal crate was build with datetime support");
+
     let mut dataset_a = Dataset::open(Path::new("fixtures/points_with_datetime.json"))?;
     let layer_a = dataset_a.layer(0)?;
 
@@ -54,6 +60,13 @@ fn run() -> Result<(), Error> {
     }
     Ok(())
 }
+
+#[cfg(not(feature = "datetime"))]
+fn run() -> Result<(), Error> {
+    println!("gdal crate was build without datetime support");
+    Ok(())
+}
+
 
 fn main() {
     run().unwrap();

--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -1,0 +1,61 @@
+extern crate gdal;
+extern crate chrono;
+
+use std::path::Path;
+use gdal::errors::Error;
+use gdal::vector::*;
+use std::fs;
+use chrono::Duration;
+use std::ops::Add;
+
+fn run() -> Result<(), Error> {
+    let mut dataset_a = Dataset::open(Path::new("fixtures/points_with_datetime.json"))?;
+    let layer_a = dataset_a.layer(0)?;
+
+    // Create a new dataset:
+    let _ = fs::remove_file("/tmp/later.geojson");
+    let drv = Driver::get("GeoJSON")?;
+    let mut ds = drv.create(Path::new("/tmp/later.geojson"))?;
+    let lyr = ds.create_layer()?;
+
+    // Copy the origin layer shema to the destination layer:
+    for field in layer_a.defn().fields() {
+        let field_defn = FieldDefn::new(&field.name(), field.field_type())?;
+        field_defn.set_width(field.width());
+        field_defn.add_to_layer(lyr)?;
+    }
+
+    // Get the definition to use on each feature:
+    let defn = Defn::from_layer(lyr);
+
+    for feature_a in layer_a.features() {
+        let mut ft = Feature::new(&defn)?;
+        ft.set_geometry(feature_a.geometry().clone())?;
+        // copy each field value of the feature:
+        for field in  defn.fields() {
+            ft.set_field(&field.name(), &match feature_a.field(&field.name())? {
+
+                // add one day to dates
+                FieldValue::DateValue(value) => {
+                    println!("{} = {}", field.name(), value);
+                    FieldValue::DateValue(value.add(Duration::days(1)))
+                },
+
+                // add 6 hours to datetimes
+                FieldValue::DateTimeValue(value) => {
+                    println!("{} = {}", field.name(), value);
+                    FieldValue::DateTimeValue(value.add(Duration::hours(6)))
+                },
+                v => v
+            })?;
+        }
+        // Add the feature to the layer:
+        ft.create(lyr)?;
+    }
+    Ok(())
+}
+
+fn main() {
+    run().unwrap();
+}
+

--- a/fixtures/points_with_datetime.json
+++ b/fixtures/points_with_datetime.json
@@ -1,0 +1,19 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          34.4,
+          12.3
+        ]
+      },
+      "properties": {
+        "dt": "2011-07-14T19:43:37-0500",
+        "d": "2018-01-04"
+      }
+    }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate num_traits;
 
 #[cfg(feature = "ndarray")]
 extern crate ndarray;
+extern crate chrono;
 
 pub use version::version_info;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ extern crate num_traits;
 
 #[cfg(feature = "ndarray")]
 extern crate ndarray;
+
+#[cfg(feature = "datetime")]
 extern crate chrono;
 
 pub use version::version_info;


### PR DESCRIPTION
This PR adds read and write support for Date and Datetime fields in the OGR API. An example is provided.

This also brings in the `chrono` crate as an additional dependency.