### PR TITLE
Define Geometry Intersection trait and implement it for Geometry

### DIFF
--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -43,7 +43,7 @@ impl Geometry {
         *(self.c_geometry_ref.borrow_mut()) = Some(c_geometry);
     }
 
-    unsafe fn with_c_geometry(c_geom: OGRGeometryH, owned: bool) -> Geometry {
+    pub(crate) unsafe fn with_c_geometry(c_geom: OGRGeometryH, owned: bool) -> Geometry {
         Geometry {
             c_geometry_ref: RefCell::new(Some(c_geom)),
             owned,

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -21,6 +21,7 @@ pub use crate::vector::driver::Driver;
 pub use crate::vector::feature::{Feature, FieldValue};
 pub use crate::vector::geometry::Geometry;
 pub use crate::vector::layer::{FeatureIterator, FieldDefn, Layer};
+pub use crate::vector::ops::geometry::intersection::Intersection as GeometryIntersection;
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
 
 use crate::errors::Result;
@@ -38,6 +39,7 @@ mod gdal_to_geo;
 mod geo_to_gdal;
 mod geometry;
 mod layer;
+mod ops;
 
 #[cfg(test)]
 mod tests;

--- a/src/vector/ops/geometry/intersection.rs
+++ b/src/vector/ops/geometry/intersection.rs
@@ -1,0 +1,90 @@
+use crate::vector::Geometry;
+use gdal_sys::OGR_G_Intersection;
+
+/// An intersection between Geometry/Geometry returning the same type.
+pub trait Intersection
+where
+    Self: Sized,
+{
+    /// Compute intersection.
+    ///
+    /// Generates a new geometry which is the region of intersection of
+    /// the two geometries operated on. Call intersects (Not yet implemented)
+    /// to check if there is a region of intersection.
+    /// Geometry validity is not checked. In case you are unsure of the
+    /// validity of the input geometries, call IsValid() before,
+    /// otherwise the result might be wrong.
+    ///
+    /// # Returns
+    /// Some(Geometry) if both Geometries contain pointers
+    /// None if either geometry is missing the gdal pointer, or there is an error.
+    fn intersection(&self, other: &Self) -> Option<Self>;
+}
+
+impl Intersection for Geometry {
+    fn intersection(&self, other: &Self) -> Option<Self> {
+        if !self.has_gdal_ptr() {
+            return None;
+        }
+        if !other.has_gdal_ptr() {
+            return None;
+        }
+        unsafe {
+            let ogr_geom = OGR_G_Intersection(self.c_geometry(), other.c_geometry());
+            if ogr_geom.is_null() {
+                return None;
+            }
+            Some(Geometry::with_c_geometry(ogr_geom, true))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intersection_success() {
+        let geom =
+            Geometry::from_wkt("POLYGON ((0.0 10.0, 0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0))")
+                .unwrap();
+        let other =
+            Geometry::from_wkt("POLYGON ((0.0 5.0, 0.0 0.0, 5.0 0.0, 5.0 5.0, 0.0 5.0))").unwrap();
+
+        let inter = geom.intersection(&other);
+
+        assert!(inter.is_some());
+
+        let inter = inter.unwrap();
+
+        assert_eq!(inter.area(), 25.0);
+    }
+
+    #[test]
+    fn test_intersection_no_gdal_ptr() {
+        let geom =
+            Geometry::from_wkt("POLYGON ((0.0 10.0, 0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0))")
+                .unwrap();
+        let other = unsafe { Geometry::lazy_feature_geometry() };
+
+        let inter = geom.intersection(&other);
+
+        assert!(inter.is_none());
+    }
+
+    #[test]
+    fn test_intersection_no_intersects() {
+        let geom =
+            Geometry::from_wkt("POLYGON ((0.0 5.0, 0.0 0.0, 5.0 0.0, 5.0 5.0, 0.0 5.0))").unwrap();
+
+        let other =
+            Geometry::from_wkt("POLYGON ((15.0 15.0, 15.0 20.0, 20.0 20.0, 20.0 15.0, 15.0 15.0))")
+                .unwrap();
+
+        let inter = geom.intersection(&other);
+
+        assert!(inter.is_some());
+
+        assert_eq!(inter.unwrap().area(), 0.0);
+    }
+}

--- a/src/vector/ops/geometry/mod.rs
+++ b/src/vector/ops/geometry/mod.rs
@@ -1,0 +1,1 @@
+pub mod intersection;

--- a/src/vector/ops/mod.rs
+++ b/src/vector/ops/mod.rs
@@ -1,0 +1,1 @@
+pub mod geometry;


### PR DESCRIPTION
I built off of #75 since it is already approved. 

gdal-sys has vector methods for both layers and geometries. It would be nice if these operations could use one trait, but unfortunately the intersection function signature for layers and geometries is much different.

Seeking comments on the location for these traits. I went with `crate::vector::ops::geometry::intersection`.