### PR TITLE
Detect GDAL version at build time / remove version features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ edition = "2018"
 
 [features]
 bindgen = ["gdal-sys/bindgen"]
-gdal_2_2 = ["gdal-sys/min_gdal_version_2_2"]
-gdal_2_4 = ["gdal-sys/min_gdal_version_2_4"]
-gdal_3_0 = ["gdal-sys/min_gdal_version_3_0"]
 array = ["ndarray"]
 datetime = ["chrono"]
 
@@ -25,10 +22,13 @@ failure_derive = "0.1"
 libc = "0.2"
 geo-types = "0.4"
 gdal-sys = { path = "gdal-sys", version = "0.2"}
-#gdal-sys = "0.2"
 num-traits = "0.2"
 ndarray = {version = "0.12.1", optional = true }
 chrono = { version = "0.4", optional = true }
+
+[build-dependencies]
+gdal-sys = { path = "gdal-sys", version = "0.2"}
+semver = "0.11"
 
 [workspace]
 members = ["gdal-sys"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,45 @@
+use gdal_sys;
+use semver::Version;
+
+pub fn gdal_version_info(key: &str) -> String {
+    let c_key = std::ffi::CString::new(key.as_bytes()).unwrap();
+    let version_string = unsafe {
+        let res_ptr = gdal_sys::GDALVersionInfo(c_key.as_ptr());
+        let c_res = std::ffi::CStr::from_ptr(res_ptr);
+        c_res.to_string_lossy().into_owned()
+    };
+    version_string
+}
+
+fn main() {
+    let gdal_version_string = gdal_version_info("--version"); // This expects GDAL to repond with "GDAL Semver , RELEASE DATE"
+    println!("GDAL version string: \"{}\"", gdal_version_string);
+
+    let semver_substring = &gdal_version_string[4..gdal_version_string.find(",").unwrap_or(12)];
+    println!("GDAL semver string: \"{}\"", semver_substring);
+
+    let detected_version = Version::parse(semver_substring).expect("Could not parse gdal version!");
+
+    println!("cargo:rustc-cfg=gdal_{}", detected_version.major);
+    println!(
+        "cargo:rustc-cfg=gdal_{}_{}",
+        detected_version.major, detected_version.minor
+    );
+    println!(
+        "cargo:rustc-cfg=gdal_{}_{}_{}",
+        detected_version.major, detected_version.minor, detected_version.patch
+    );
+
+    // we only support GDAL >= 2.0.
+    for major in 2..=detected_version.major {
+        println!("cargo:rustc-cfg=major_ge_{}", major);
+    }
+
+    for minor in 0..=detected_version.minor {
+        println!("cargo:rustc-cfg=minor_ge_{}", minor);
+    }
+
+    for patch in 0..=detected_version.patch {
+        println!("cargo:rustc-cfg=patch_ge_{}", patch);
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,10 @@ fn main() {
         detected_version.major, detected_version.minor, detected_version.patch
     );
 
+    println!("cargo:rustc-cfg=major_is_{}", detected_version.major);
+    println!("cargo:rustc-cfg=minor_is_{}", detected_version.minor);
+    println!("cargo:rustc-cfg=patch_is_{}", detected_version.patch);
+
     // we only support GDAL >= 2.0.
     for major in 2..=detected_version.major {
         println!("cargo:rustc-cfg=major_ge_{}", major);

--- a/gdal-sys/Cargo.toml
+++ b/gdal-sys/Cargo.toml
@@ -7,19 +7,10 @@ repository = "https://github.com/georust/gdal"
 authors = ["Johannes Drönner <droenner@informatik.uni-marburg.de>"]
 edition = "2018"
 
-[features]
-default = ["min_gdal_version_1_11"]
-min_gdal_version_1_11 = []
-min_gdal_version_2_0 = []
-min_gdal_version_2_1 = []
-min_gdal_version_2_2 = []
-min_gdal_version_2_3 = []
-min_gdal_version_2_4 = []
-min_gdal_version_3_0 = []
-
 [dependencies]
 libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.54", optional = true }
 pkg-config = "0.3"
+semver = "0.11"

--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -192,7 +192,7 @@ fn main() {
                 version.major, version.minor
             ));
             if !binding_path.exists() {
-                panic!("No pre-build binding available for this GDAl version.");
+                panic!("No pre-built bindings available for GDAL version {}.{}. Use `--features bindgen` to generate your own bindings.", version.major, version.minor);
             }
 
             std::fs::copy(&binding_path, &out_path)

--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -197,6 +197,8 @@ fn main() {
 
             std::fs::copy(&binding_path, &out_path)
                 .expect("Can't copy bindings to output directory");
+        } else {
+            panic!("No GDAL version detected");
         }
     }
 }

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -266,7 +266,7 @@ impl<'a> RasterBand<'a> {
 
     /// Get actual block size (at the edges) when block size
     /// does not divide band size.
-    #[cfg(feature = "gdal_2_2")]
+    #[cfg(all(major_ge_2, minor_ge_2))]
     pub fn actual_block_size(&self, offset: (isize, isize)) -> Result<(usize, usize)> {
         let mut block_size_x = 0;
         let mut block_size_y = 0;

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -364,7 +364,7 @@ fn test_get_rasterband_block_size() {
 }
 
 #[test]
-#[cfg(feature = "gdal_2_2")]
+#[cfg(all(major_ge_2, minor_ge_2))]
 fn test_get_rasterband_actual_block_size() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
     let rasterband = dataset.rasterband(1).unwrap();

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -304,14 +304,14 @@ impl SpatialRef {
         }
     }
 
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     pub fn set_axis_mapping_strategy(&self, strategy: gdal_sys::OSRAxisMappingStrategy::Type) {
         unsafe {
             gdal_sys::OSRSetAxisMappingStrategy(self.0, strategy);
         }
     }
 
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     pub fn get_axis_mapping_strategy(&self) -> gdal_sys::OSRAxisMappingStrategy::Type {
         unsafe { gdal_sys::OSRGetAxisMappingStrategy(self.0) }
     }

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -24,9 +24,9 @@ fn from_proj4_to_wkt() {
     )
     .unwrap();
     // TODO: handle proj changes on lib level
-    #[cfg(not(feature = "gdal_3_0"))]
+    #[cfg(not(major_ge_3))]
     assert_eq!(spatial_ref.to_wkt().unwrap(), "PROJCS[\"unnamed\",GEOGCS[\"GRS 1980(IUGG, 1980)\",DATUM[\"unknown\",SPHEROID[\"GRS80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]],PROJECTION[\"Lambert_Azimuthal_Equal_Area\"],PARAMETER[\"latitude_of_center\",52],PARAMETER[\"longitude_of_center\",10],PARAMETER[\"false_easting\",4321000],PARAMETER[\"false_northing\",3210000],UNIT[\"Meter\",1]]");
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     assert_eq!(spatial_ref.to_wkt().unwrap(), "PROJCS[\"unknown\",GEOGCS[\"unknown\",DATUM[\"Unknown based on GRS80 ellipsoid\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Lambert_Azimuthal_Equal_Area\"],PARAMETER[\"latitude_of_center\",52],PARAMETER[\"longitude_of_center\",10],PARAMETER[\"false_easting\",4321000],PARAMETER[\"false_northing\",3210000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]");
 }
 
@@ -35,9 +35,9 @@ fn from_epsg_to_wkt_proj4() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
     let wkt = spatial_ref.to_wkt().unwrap();
     // TODO: handle proj changes on lib level
-    #[cfg(not(feature = "gdal_3_0"))]
+    #[cfg(not(major_ge_3))]
     assert_eq!("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]", wkt);
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     assert_eq!("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]", wkt);
     let proj4string = spatial_ref.to_proj4().unwrap();
     assert_eq!("+proj=longlat +datum=WGS84 +no_defs", proj4string.trim());
@@ -70,10 +70,10 @@ fn transform_coordinates() {
     let spatial_ref2 = SpatialRef::from_epsg(3035).unwrap();
 
     // TODO: handle axis order in tests
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     spatial_ref1
         .set_axis_mapping_strategy(gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER);
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     spatial_ref2
         .set_axis_mapping_strategy(gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER);
 
@@ -103,10 +103,10 @@ fn transform_ogr_geometry() {
     let spatial_ref2 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
 
     // TODO: handle axis order in tests
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     spatial_ref1
         .set_axis_mapping_strategy(gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER);
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     spatial_ref2
         .set_axis_mapping_strategy(gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER);
 

--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -210,7 +210,7 @@ fn test_geom_fields() {
 
     let geom_field = layer.defn().geom_fields().next().unwrap();
     let spatial_ref2 = SpatialRef::from_epsg(4326).unwrap();
-    #[cfg(feature = "gdal_3_0")]
+    #[cfg(major_ge_3)]
     spatial_ref2.set_axis_mapping_strategy(0);
 
     assert!(geom_field.spatial_ref().unwrap() == spatial_ref2);


### PR DESCRIPTION
This PR changes the build.rs file for gdal-sys and introduces a build.rs for gdal. It makes conditional compilation for version handling more convenient. However, it is still not very pretty.

In gdal-sys, the lib version is now used to select the correct binding file. On Linux it is provided by pkg-config if the gdal lib is detected.
In gdal, the features for versions are removed. The actual GDAL version is requested from gdal-sys and the config parameters are generated.

The changes for **gdal-sys** are:
- version specification as environmental variable  or auto-detection using pkg-config. (i guess windows will require the `GDAL_VERSION` variable to be set).
- no more features to select versions

The changes for **gdal** are: 
- Features for versions are removed. 
- The Current GDAL  version is requested from gdal-sys.
- Build.rs generates config parameters based on the GDAL version.


The following parameters are generated in gdals build.rs:
```
gdal_x, gdal_x_y, gdal_x_y_z with x = major, y = minor, and z= patch. (this provides backward capability to the features)
mayor_is_x, minor_is_y, patch_is_z
mayor_ge_x, minor_ge_y, patch_ge_z  for all version numbers up to the actual version. (major starts with 2).
```
For example GDAL 3.1.2 will have: --cfg major_is_3 --cfg minor_is_1 --cfg patch_is_2 --cfg major_ge_2 --cfg major_ge_3 --cfg minor_ge_0 --cfg minor_ge_1 --cfg patch_ge_0 --cfg patch_ge_1 --cfg patch_ge_2

This allows to enable methods based on versions:
```
#[all(cfg("major_ge_3"), cfg(minor_ge_1" ))]
fn method()
```