### PR TITLE
Rename spatial_reference to spatial_ref

### DIFF
--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -321,7 +321,7 @@ impl Geometry {
     /// succeeds, it returns an Ok(Some(SpatialRef)), otherwise, you get the
     /// Err.
     ///
-    pub fn spatial_reference(&self) -> Option<SpatialRef> {
+    pub fn spatial_ref(&self) -> Option<SpatialRef> {
         let c_spatial_ref = unsafe { gdal_sys::OGR_G_GetSpatialReference(self.c_geometry()) };
 
         if c_spatial_ref.is_null() {
@@ -334,7 +334,7 @@ impl Geometry {
         }
     }
 
-    pub fn set_spatial_reference(&mut self, spatial_ref: SpatialRef) {
+    pub fn set_spatial_ref(&mut self, spatial_ref: SpatialRef) {
         unsafe {
             gdal_sys::OGR_G_AssignSpatialReference(self.c_geometry(), spatial_ref.to_c_hsrs())
         };
@@ -443,19 +443,19 @@ mod tests {
     }
 
     #[test]
-    pub fn test_spatial_reference() {
+    pub fn test_spatial_ref() {
         let geom = Geometry::empty(::gdal_sys::OGRwkbGeometryType::wkbMultiPolygon).unwrap();
-        assert!(geom.spatial_reference().is_none());
+        assert!(geom.spatial_ref().is_none());
 
         let geom = Geometry::from_wkt("POINT(0 0)").unwrap();
-        assert!(geom.spatial_reference().is_none());
+        assert!(geom.spatial_ref().is_none());
 
         let wkt = "POLYGON ((45.0 45.0, 45.0 50.0, 50.0 50.0, 50.0 45.0, 45.0 45.0))";
         let mut geom = Geometry::from_wkt(wkt).unwrap();
-        assert!(geom.spatial_reference().is_none());
+        assert!(geom.spatial_ref().is_none());
 
         let srs = SpatialRef::from_epsg(4326).unwrap();
-        geom.set_spatial_reference(srs);
-        assert!(geom.spatial_reference().is_some());
+        geom.set_spatial_ref(srs);
+        assert!(geom.spatial_ref().is_some());
     }
 }

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -145,7 +145,7 @@ impl<'a> Layer<'a> {
         Ok(envelope)
     }
 
-    pub fn spatial_reference(&self) -> Result<SpatialRef> {
+    pub fn spatial_ref(&self) -> Result<SpatialRef> {
         let c_obj = unsafe { gdal_sys::OGR_L_GetSpatialRef(self.c_layer) };
         if c_obj.is_null() {
             return Err(_last_null_pointer_err("OGR_L_GetSpatialRef"));

--- a/src/vector/tests/mod.rs
+++ b/src/vector/tests/mod.rs
@@ -42,10 +42,10 @@ fn test_layer_extent() {
 }
 
 #[test]
-fn test_layer_spatial_reference() {
+fn test_layer_spatial_ref() {
     let mut ds = Dataset::open(fixture!("roads.geojson")).unwrap();
     let layer = ds.layer(0).unwrap();
-    let srs = layer.spatial_reference().unwrap();
+    let srs = layer.spatial_ref().unwrap();
     assert_eq!(srs.auth_code().unwrap(), 4326);
 }
 


### PR DESCRIPTION
There was some inconsistency in function naming:
- Geometry::spatial_reference
- Layer::spatial_reference
- GeomField::spatial_ref

I chose spatial_ref, rather than spatial_reference, as the canonical
form because:
- abbreviations are common in Rust
- "ref" for "reference" is already well-known to Rust devs, e.g. RefCell
- the returned type is called SpatialRef
- the GDAL API also consistently uses SpatialRef