### PR TITLE
update docs link to point at docs.rs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 # gdal
 
+[![Documentation](https://docs.rs/gdal/badge.svg)](https://docs.rs/gdal)
 [![Build Status](https://travis-ci.org/georust/gdal.png?branch=master)](https://travis-ci.org/georust/gdal)
-
-[Documentation](https://georust.github.io/gdal)
 
 [GDAL](http://gdal.org/) bindings for [Rust](http://www.rust-lang.org/).
 


### PR DESCRIPTION
It seems like maybe previously someone was manually producing and publishing the docs to gh-pages, and it's gotten out of date. 

It might be easier for you to just point to docs.rs which automatically builds your docs whenever you publish.