### PR TITLE
better error when pkg-config is not installed.

### DIFF
--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -223,7 +223,12 @@ fn main() {
                 .expect("Can't copy bindings to output directory");
         } else {
             if let Err(pkg_config_err) = &gdal_pkg_config {
-                panic!("Error while running `pkg-config`: {}", pkg_config_err);
+                // Special case output for this common error
+                if matches!(pkg_config_err, pkg_config::Error::Command { cause, .. } if cause.kind() == std::io::ErrorKind::NotFound) {
+                    panic!("Could not find `pkg-config` in your path. Please install it before building gdal-sys.");
+                } else {
+                    panic!("Error while running `pkg-config`: {}", pkg_config_err);
+                }
             } else {
                 panic!("No GDAL version detected");
             }

--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -184,13 +184,13 @@ fn main() {
         include_paths.push(dir.as_path().to_str().unwrap().to_string());
     }
 
-    let gdal = Config::new()
+    let gdal_pkg_config = Config::new()
         .statik(prefer_static)
         .cargo_metadata(need_metadata)
         .probe("gdal");
 
-    if let Ok(gdal) = gdal {
-        for dir in gdal.include_paths {
+    if let Ok(gdal) = &gdal_pkg_config {
+        for dir in &gdal.include_paths {
             include_paths.push(dir.to_str().unwrap().to_string());
         }
         if version.is_none() {
@@ -222,7 +222,11 @@ fn main() {
             std::fs::copy(&binding_path, &out_path)
                 .expect("Can't copy bindings to output directory");
         } else {
-            panic!("No GDAL version detected");
+            if let Err(pkg_config_err) = &gdal_pkg_config {
+                panic!("Error while running `pkg-config`: {}", pkg_config_err);
+            } else {
+                panic!("No GDAL version detected");
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #137

If pkg-config is not installed on your system you should see error output like this:

```
$ cargo build                                                 
   Compiling gdal-sys v0.3.1 (/Users/mkirk/src/georust/gdal/gdal-sys)
error: failed to run custom build command for `gdal-sys v0.3.1 (/Users/mkirk/src/georust/gdal/gdal-sys)`

Caused by:
  process didn't exit successfully: `/Users/mkirk/src/georust/gdal/target/debug/build/gdal-sys-e669765d1e341154/build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=GDAL_STATIC
  cargo:rerun-if-env-changed=GDAL_DYNAMIC
  cargo:rerun-if-env-changed=GDAL_INCLUDE_DIR
  cargo:rerun-if-env-changed=GDAL_LIB_DIR
  cargo:rerun-if-env-changed=GDAL_HOME
  cargo:rerun-if-env-changed=GDAL_VERSION
  cargo:rerun-if-env-changed=GDAL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-apple-darwin
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_apple_darwin
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at 'Could not find `pkg-config` in your path. Please install it before building gdal-sys.', gdal-sys/build.rs:228:21
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```