### PR TITLE
Select resampling algo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # Changes
 
 ## Unreleased
+
+* **Breaking**: Add support to select a resampling algorithm when reading a raster
+    * <https://github.com/georust/gdal/pull/141>
+
+    Now, it is necessary to provide a `Option<ResampleAlg>` when reading a raster.
+    If `None`, it uses `ResampleAlg::NearestNeighbour` which was the
+    default behavior.
+
 * Implement wrapper for `OGR_L_TestCapability`
     * <https://github.com/georust/gdal/pull/160>
 * **Breaking**: Use `DatasetOptions` to pass as `Dataset::open_ex` parameters and
@@ -76,8 +84,11 @@
   `SpatialRef::axis_mapping_strategy` instead.
 * Add support for reading and setting rasterband colour interpretations
     * <https://github.com/georust/gdal/pull/144>
+<<<<<<< HEAD
 * Fixed memory leak in `Geometry::from_wkt`
     * <https://github.com/georust/gdal/pull/172>
+=======
+>>>>>>> Added entry to CHANGES
 
 ## 0.7.1
 * fix docs.rs build for gdal-sys

--- a/examples/rasterband.rs
+++ b/examples/rasterband.rs
@@ -13,7 +13,7 @@ fn main() {
     println!("rasterband type: {:?}", rasterband.band_type());
     println!("rasterband scale: {:?}", rasterband.scale());
     println!("rasterband offset: {:?}", rasterband.offset());
-    if let Ok(rv) = rasterband.read_as::<u8>((20, 30), (2, 3), (2, 3)) {
+    if let Ok(rv) = rasterband.read_as::<u8>((20, 30), (2, 3), (2, 3), None) {
         println!("{:?}", rv.data);
     }
 }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -294,6 +294,7 @@ fn test_read_raster_as_array() {
             (left, top),
             (window_size_x, window_size_y),
             (array_size_x, array_size_y),
+            None,
         )
         .unwrap();
 

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -1,8 +1,9 @@
 use crate::dataset::Dataset;
 use crate::metadata::Metadata;
+use crate::raster::rasterband::ResampleAlg;
 use crate::raster::{ByteBuffer, ColorInterpretation};
 use crate::Driver;
-use gdal_sys::{GDALDataType, GDALRIOResampleAlg};
+use gdal_sys::GDALDataType;
 use std::path::Path;
 
 #[cfg(feature = "ndarray")]
@@ -103,16 +104,16 @@ fn test_read_raster_with_default_resample() {
 fn test_read_raster_with_average_resample() {
     let dataset = Dataset::open(fixture!("tinymarble.png")).unwrap();
     let rb = dataset.rasterband(1).unwrap();
-    let resample_alg = Some(GDALRIOResampleAlg::GRIORA_Average);
+    let resample_alg = ResampleAlg::Average;
     let rv = rb
-        .read_as::<u8>((20, 30), (4, 4), (2, 2), resample_alg)
+        .read_as::<u8>((20, 30), (4, 4), (2, 2), Some(resample_alg))
         .unwrap();
     assert_eq!(rv.size.0, 2);
     assert_eq!(rv.size.1, 2);
     assert_eq!(rv.data, vec!(8, 6, 8, 12));
 
     let mut buf = rv;
-    rb.read_into_slice((20, 30), (4, 4), (2, 2), &mut buf.data, resample_alg)
+    rb.read_into_slice((20, 30), (4, 4), (2, 2), &mut buf.data, Some(resample_alg))
         .unwrap();
     assert_eq!(buf.data, vec!(8, 6, 8, 12));
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR changes the functions used to read rasters by adding an extra parameter to select the resampling algorithm used when `buffer_size != window size` (GDAL needs to interpolate the values) (closes #140)