### PR TITLE
Add more SpatialRef methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,8 @@
 # Changes
 
-## unreleased
-* Add more functions to SpatialRef implementation
-
 ## Unreleased
+* Add more functions to SpatialRef implementation
+    * <https://github.com/georust/gdal/pull/145>   
 * **Breaking**: Change `Feature::field` return type from
   `Result<FieldValue>` to `Result<Option<FieldValue>>`. Fields
   can be null. Before this change, if a field was null, the value

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## unreleased
+* Add more functions to SpatialRef implementation
+
 ## Unreleased
 * **Breaking**: Change `Feature::field` return type from
   `Result<FieldValue>` to `Result<Option<FieldValue>>`. Fields

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,4 +57,9 @@ pub enum GdalError {
         to: String,
         msg: Option<String>,
     },
+    #[error("Axis not found for key '{key}' in method '{method_name}'")]
+    AxisNotFoundError {
+        key: String,
+        method_name: &'static str,
+    },
 }

--- a/src/spatial_ref/mod.rs
+++ b/src/spatial_ref/mod.rs
@@ -1,7 +1,7 @@
 mod srs;
 
-pub use srs::{ CoordTransform, SpatialRef, AxisOrientationType };
-pub use gdal_sys::{ OGRAxisOrientation };
+pub use gdal_sys::OGRAxisOrientation;
+pub use srs::{AxisOrientationType, CoordTransform, SpatialRef};
 
 #[cfg(test)]
 mod tests;

--- a/src/spatial_ref/mod.rs
+++ b/src/spatial_ref/mod.rs
@@ -1,7 +1,7 @@
 mod srs;
 
-pub use srs::CoordTransform;
-pub use srs::SpatialRef;
+pub use srs::{ CoordTransform, SpatialRef, AxisOrientationType };
+pub use gdal_sys::{ OGRAxisOrientation };
 
 #[cfg(test)]
 mod tests;

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -78,6 +78,18 @@ impl CoordTransform {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct AreaOfUse {
+    pub west_lon_degree: f64,
+    pub south_lat_degree: f64,
+    pub east_lon_degree: f64,
+    pub north_lat_degree: f64,
+    pub name: String,
+}
+
+pub type AxisOrientationType = gdal_sys::OGRAxisOrientation::Type;
+
+
 #[derive(Debug)]
 pub struct SpatialRef(OGRSpatialReferenceH);
 
@@ -304,6 +316,103 @@ impl SpatialRef {
     }
 
     #[cfg(major_ge_3)]
+    pub fn get_name(&self) -> Result<String> {
+        let c_ptr = unsafe { gdal_sys::OSRGetName(self.0) };
+        if c_ptr.is_null() {
+            return Err(_last_null_pointer_err("OSRGetName"));
+        }
+        Ok(_string(c_ptr))
+    }
+
+    pub fn get_angular_units_name(&self) -> Result<String> {
+        let mut c_ptr = ptr::null_mut();
+        unsafe { gdal_sys::OSRGetAngularUnits(self.0, &mut c_ptr) };
+        if c_ptr.is_null() {
+            return Err(_last_null_pointer_err("OSRGetAngularUnits"));
+        }
+        Ok(_string(c_ptr))
+    }
+
+    pub fn get_angular_units(&self) -> f64 {
+        unsafe { gdal_sys::OSRGetAngularUnits(self.0, ptr::null_mut()) }
+    }
+
+    pub fn get_linear_units_name(&self) -> Result<String> {
+        let mut c_ptr = ptr::null_mut();
+        unsafe { gdal_sys::OSRGetLinearUnits(self.0, &mut c_ptr) };
+        if c_ptr.is_null() {
+            return Err(_last_null_pointer_err("OSRGetLinearUnits"));
+        }
+        Ok(_string(c_ptr))
+    }
+
+    pub fn get_linear_units(&self) -> f64 {
+        unsafe { gdal_sys::OSRGetLinearUnits(self.0, ptr::null_mut()) }
+    }
+    
+    #[inline]
+    pub fn is_geographic(&self) -> bool {
+        unsafe { gdal_sys::OSRIsGeographic(self.0) == 1 }
+    }
+
+    #[inline]
+    #[cfg(all(major_ge_3, minor_ge_1))]
+    pub fn is_derived_geographic(&self) -> bool {
+        unsafe { gdal_sys::OSRIsDerivedGeographic(self.0) == 1 }
+    }
+
+    #[inline] 
+    pub fn is_local(&self) -> bool {
+        unsafe { gdal_sys::OSRIsLocal(self.0) == 1 }
+    }
+
+    #[inline]
+    pub fn is_projected(&self) -> bool {
+        unsafe { gdal_sys::OSRIsProjected(self.0) == 1 }
+    }
+
+    #[inline]
+    pub fn is_compound(&self) -> bool {
+        unsafe { gdal_sys::OSRIsCompound(self.0) == 1 }
+    }
+
+    #[inline]
+    pub fn is_geocentric(&self) -> bool {
+        unsafe { gdal_sys::OSRIsGeocentric(self.0) == 1 }
+    }
+
+    #[inline]
+    pub fn is_vertical(&self) -> bool {
+        unsafe { gdal_sys::OSRIsVertical(self.0)  == 1 }
+    }
+
+    pub fn get_axis_orientation(&self, target_key: &str, axis: i32 ) -> AxisOrientationType {
+        // We can almost safely assume that if we fail to build a CString then the input 
+        // is not a valide key. 
+        let mut orientation = gdal_sys::OGRAxisOrientation::OAO_Other;
+        if let Ok(c_str) =  CString::new(target_key) {
+            unsafe { gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, &mut orientation) };
+        }
+        orientation
+    }
+
+    pub fn get_axis_name(&self, target_key: &str, axis: i32 ) -> Option<String> {
+        // See get_axis_orientation
+        if let Ok(c_str) = CString::new(target_key) {
+            let c_ptr = unsafe { gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, ptr::null_mut()) };
+            // null ptr indicate a failure (but no CPLError) see Gdal documentation.
+            if c_ptr.is_null() { None } else { Some(_string(c_ptr)) }
+        } else {
+            None
+        }
+    }
+
+    #[cfg(all(major_ge_3, minor_ge_1))]
+    pub fn get_axes_count(&self) -> i32 {
+        unsafe { gdal_sys::OSRGetAxesCount(self.0) } 
+    }
+
+    #[cfg(major_ge_3)]
     pub fn set_axis_mapping_strategy(&self, strategy: gdal_sys::OSRAxisMappingStrategy::Type) {
         unsafe {
             gdal_sys::OSRSetAxisMappingStrategy(self.0, strategy);
@@ -313,6 +422,33 @@ impl SpatialRef {
     #[cfg(major_ge_3)]
     pub fn get_axis_mapping_strategy(&self) -> gdal_sys::OSRAxisMappingStrategy::Type {
         unsafe { gdal_sys::OSRGetAxisMappingStrategy(self.0) }
+    }
+
+    #[cfg(major_ge_3)]
+    pub fn get_area_of_use(&self) -> Option<AreaOfUse> {
+        let mut c_area_name: *const libc::c_char = ptr::null_mut();
+        let (mut w_long, mut s_lat, mut e_long, mut n_lat): (f64, f64, f64, f64) = (0.0,0.0,0.0,0.0);
+        let ret_val = unsafe {
+            gdal_sys::OSRGetAreaOfUse(
+                self.0,
+                &mut w_long,
+                &mut s_lat,
+                &mut e_long,
+                &mut n_lat,
+                &mut c_area_name
+            ) == 1 
+        };
+
+        if ret_val {
+            Some(AreaOfUse {
+                west_lon_degree: w_long,
+                south_lat_degree: s_lat,
+                east_lon_degree: e_long,
+                north_lat_degree: n_lat,
+                name: _string(c_area_name) })
+        } else {
+            None
+        }
     }
 
     // TODO: should this take self instead of &self?

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -89,7 +89,6 @@ pub struct AreaOfUse {
 
 pub type AxisOrientationType = gdal_sys::OGRAxisOrientation::Type;
 
-
 #[derive(Debug)]
 pub struct SpatialRef(OGRSpatialReferenceH);
 
@@ -349,7 +348,7 @@ impl SpatialRef {
     pub fn get_linear_units(&self) -> f64 {
         unsafe { gdal_sys::OSRGetLinearUnits(self.0, ptr::null_mut()) }
     }
-    
+
     #[inline]
     pub fn is_geographic(&self) -> bool {
         unsafe { gdal_sys::OSRIsGeographic(self.0) == 1 }
@@ -361,7 +360,7 @@ impl SpatialRef {
         unsafe { gdal_sys::OSRIsDerivedGeographic(self.0) == 1 }
     }
 
-    #[inline] 
+    #[inline]
     pub fn is_local(&self) -> bool {
         unsafe { gdal_sys::OSRIsLocal(self.0) == 1 }
     }
@@ -383,25 +382,33 @@ impl SpatialRef {
 
     #[inline]
     pub fn is_vertical(&self) -> bool {
-        unsafe { gdal_sys::OSRIsVertical(self.0)  == 1 }
+        unsafe { gdal_sys::OSRIsVertical(self.0) == 1 }
     }
 
-    pub fn get_axis_orientation(&self, target_key: &str, axis: i32 ) -> AxisOrientationType {
-        // We can almost safely assume that if we fail to build a CString then the input 
-        // is not a valide key. 
+    pub fn get_axis_orientation(&self, target_key: &str, axis: i32) -> AxisOrientationType {
+        // We can almost safely assume that if we fail to build a CString then the input
+        // is not a valide key.
         let mut orientation = gdal_sys::OGRAxisOrientation::OAO_Other;
-        if let Ok(c_str) =  CString::new(target_key) {
-            unsafe { gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, &mut orientation) };
+        if let Ok(c_str) = CString::new(target_key) {
+            unsafe {
+                gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, &mut orientation)
+            };
         }
         orientation
     }
 
-    pub fn get_axis_name(&self, target_key: &str, axis: i32 ) -> Option<String> {
+    pub fn get_axis_name(&self, target_key: &str, axis: i32) -> Option<String> {
         // See get_axis_orientation
         if let Ok(c_str) = CString::new(target_key) {
-            let c_ptr = unsafe { gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, ptr::null_mut()) };
+            let c_ptr = unsafe {
+                gdal_sys::OSRGetAxis(self.0, c_str.as_ptr(), axis as c_int, ptr::null_mut())
+            };
             // null ptr indicate a failure (but no CPLError) see Gdal documentation.
-            if c_ptr.is_null() { None } else { Some(_string(c_ptr)) }
+            if c_ptr.is_null() {
+                None
+            } else {
+                Some(_string(c_ptr))
+            }
         } else {
             None
         }
@@ -409,7 +416,7 @@ impl SpatialRef {
 
     #[cfg(all(major_ge_3, minor_ge_1))]
     pub fn get_axes_count(&self) -> i32 {
-        unsafe { gdal_sys::OSRGetAxesCount(self.0) } 
+        unsafe { gdal_sys::OSRGetAxesCount(self.0) }
     }
 
     #[cfg(major_ge_3)]
@@ -427,7 +434,8 @@ impl SpatialRef {
     #[cfg(major_ge_3)]
     pub fn get_area_of_use(&self) -> Option<AreaOfUse> {
         let mut c_area_name: *const libc::c_char = ptr::null_mut();
-        let (mut w_long, mut s_lat, mut e_long, mut n_lat): (f64, f64, f64, f64) = (0.0,0.0,0.0,0.0);
+        let (mut w_long, mut s_lat, mut e_long, mut n_lat): (f64, f64, f64, f64) =
+            (0.0, 0.0, 0.0, 0.0);
         let ret_val = unsafe {
             gdal_sys::OSRGetAreaOfUse(
                 self.0,
@@ -435,8 +443,8 @@ impl SpatialRef {
                 &mut s_lat,
                 &mut e_long,
                 &mut n_lat,
-                &mut c_area_name
-            ) == 1 
+                &mut c_area_name,
+            ) == 1
         };
 
         if ret_val {
@@ -445,7 +453,8 @@ impl SpatialRef {
                 south_lat_degree: s_lat,
                 east_lon_degree: e_long,
                 north_lat_degree: n_lat,
-                name: _string(c_area_name) })
+                name: _string(c_area_name),
+            })
         } else {
             None
         }

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -222,3 +222,89 @@ fn axis_mapping_strategy() {
         gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER
     );
 }
+
+#[cfg(major_ge_3)]
+#[test]
+fn get_area_of_use() {
+    let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
+    let area_of_use = spatial_ref.get_area_of_use().unwrap();
+    assert_eq!(area_of_use.west_lon_degree, -180.0);
+    assert_eq!(area_of_use.south_lat_degree, -90.0);
+    assert_eq!(area_of_use.east_lon_degree, 180.0);
+    assert_eq!(area_of_use.north_lat_degree, 90.0);
+}
+
+#[cfg(major_ge_3)]
+#[test]
+fn get_name() {
+    let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
+    let name = spatial_ref.get_name().unwrap();
+    assert_eq!(name,"WGS 84");
+}
+
+
+#[test]
+fn get_units_epsg4326() {
+    let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
+
+    let angular_units_name = spatial_ref.get_angular_units_name().unwrap();
+    assert_eq!(angular_units_name.to_lowercase(), "degree");
+    let to_radians = spatial_ref.get_angular_units();
+    assert_almost_eq(to_radians, 0.01745329);
+}
+
+#[test]
+fn get_units_epsg2154() {
+    let spatial_ref = SpatialRef::from_epsg(2154).unwrap();
+    let linear_units_name = spatial_ref.get_linear_units_name().unwrap();
+    assert_eq!(linear_units_name.to_lowercase(), "metre");
+    let to_meters = spatial_ref.get_linear_units();
+    assert_almost_eq(to_meters, 1.0);
+}
+
+#[test]
+fn predicats_epsg4326() {
+    let spatial_ref_4326 = SpatialRef::from_epsg(4326).unwrap();
+    assert!(spatial_ref_4326.is_geographic());
+    assert!(!spatial_ref_4326.is_local());
+    assert!(!spatial_ref_4326.is_projected());
+    assert!(!spatial_ref_4326.is_compound());
+    assert!(!spatial_ref_4326.is_geocentric());
+    assert!(!spatial_ref_4326.is_vertical());
+
+    #[cfg(all(major_ge_3, minor_ge_1))]
+    assert!(!spatial_ref_4326.is_derived_geographic());
+}
+
+#[test]
+fn predicats_epsg2154() {
+    let spatial_ref_2154 = SpatialRef::from_epsg(2154).unwrap();
+    assert!(!spatial_ref_2154.is_geographic());
+    assert!(!spatial_ref_2154.is_local());
+    assert!(spatial_ref_2154.is_projected());
+    assert!(!spatial_ref_2154.is_compound());
+    assert!(!spatial_ref_2154.is_geocentric());
+
+    #[cfg(all(major_ge_3, minor_ge_1))]
+    assert!(!spatial_ref_2154.is_derived_geographic());
+} 
+
+//XXX Gdal 2 implementation is partial
+#[cfg(major_ge_3)] 
+#[test]
+fn crs_axis() {
+    let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
+
+    #[cfg(all(major_ge_3, minor_ge_1))]
+    assert_eq!(spatial_ref.get_axes_count(),2);
+    
+    let orientation = spatial_ref.get_axis_orientation("GEOGCS",0);
+    assert_eq!(orientation,gdal_sys::OGRAxisOrientation::OAO_North);
+
+    assert!(spatial_ref.get_axis_name("GEOGCS",0).is_some());
+    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS",0).is_none());
+
+    let orientation = spatial_ref.get_axis_orientation("DO_NO_EXISTS",0);
+    assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_Other);
+}
+

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -228,10 +228,10 @@ fn axis_mapping_strategy() {
 fn get_area_of_use() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
     let area_of_use = spatial_ref.get_area_of_use().unwrap();
-    assert_eq!(area_of_use.west_lon_degree, -180.0);
-    assert_eq!(area_of_use.south_lat_degree, -90.0);
-    assert_eq!(area_of_use.east_lon_degree, 180.0);
-    assert_eq!(area_of_use.north_lat_degree, 90.0);
+    assert_almost_eq(area_of_use.west_lon_degree, -180.0);
+    assert_almost_eq(area_of_use.south_lat_degree, -90.0);
+    assert_almost_eq(area_of_use.east_lon_degree, 180.0);
+    assert_almost_eq(area_of_use.north_lat_degree, 90.0);
 }
 
 #[cfg(major_ge_3)]
@@ -239,9 +239,8 @@ fn get_area_of_use() {
 fn get_name() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
     let name = spatial_ref.get_name().unwrap();
-    assert_eq!(name,"WGS 84");
+    assert_eq!(name, "WGS 84");
 }
-
 
 #[test]
 fn get_units_epsg4326() {
@@ -287,24 +286,23 @@ fn predicats_epsg2154() {
 
     #[cfg(all(major_ge_3, minor_ge_1))]
     assert!(!spatial_ref_2154.is_derived_geographic());
-} 
+}
 
 //XXX Gdal 2 implementation is partial
-#[cfg(major_ge_3)] 
+#[cfg(major_ge_3)]
 #[test]
 fn crs_axis() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
 
     #[cfg(all(major_ge_3, minor_ge_1))]
-    assert_eq!(spatial_ref.get_axes_count(),2);
-    
-    let orientation = spatial_ref.get_axis_orientation("GEOGCS",0);
-    assert_eq!(orientation,gdal_sys::OGRAxisOrientation::OAO_North);
+    assert_eq!(spatial_ref.get_axes_count(), 2);
 
-    assert!(spatial_ref.get_axis_name("GEOGCS",0).is_some());
-    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS",0).is_none());
+    let orientation = spatial_ref.get_axis_orientation("GEOGCS", 0);
+    assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_North);
 
-    let orientation = spatial_ref.get_axis_orientation("DO_NO_EXISTS",0);
+    assert!(spatial_ref.get_axis_name("GEOGCS", 0).is_some());
+    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS", 0).is_none());
+
+    let orientation = spatial_ref.get_axis_orientation("DO_NO_EXISTS", 0);
     assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_Other);
 }
-

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -297,12 +297,9 @@ fn crs_axis() {
     #[cfg(all(major_ge_3, minor_ge_1))]
     assert_eq!(spatial_ref.get_axes_count(), 2);
 
-    let orientation = spatial_ref.get_axis_orientation("GEOGCS", 0);
+    let orientation = spatial_ref.get_axis_orientation("GEOGCS", 0).unwrap();
     assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_North);
-
-    assert!(spatial_ref.get_axis_name("GEOGCS", 0).is_some());
-    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS", 0).is_none());
-
-    let orientation = spatial_ref.get_axis_orientation("DO_NO_EXISTS", 0);
-    assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_Other);
+    assert!(spatial_ref.get_axis_name("GEOGCS", 0).is_ok());
+    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS", 0).is_err());
+    assert!(spatial_ref.get_axis_orientation("DO_NO_EXISTS", 0).is_err());
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR add more bridge functions to gdal::spatial_ref::srs::SpatialRef implementation.

Struct added

* AreaOfUse

Type alias

* AxisOrientationType 

Functions added:

* get_name
* get_angular_units
* get_angular_units_name
* get_linear_units
* get_linear_units_name
* is_geographic
* is_derived_geographic
* is_local
* is_projected
* is_compound
* is_geocentric
* is_vertical
* get_axis_orientation
* get_axis_name
* get_axes_count
* get_area_of_use

Added tests.
