### PR TITLE
update to geo-types 0.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
 # Changes
+
+## UNRELEASED
+
+* BREAKING: update geo-types to 0.7.0. geo-types Coordinate<T> now implement
+  `Debug`
+  * <https://github.com/georust/gdal/pull/146>
+
 ## 0.7.1
 * fix docs.rs build for gdal-sys
     * <https://github.com/georust/gdal/pull/128>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ datetime = ["chrono"]
 [dependencies]
 thiserror = "1.0"
 libc = "0.2"
-geo-types = "0.6"
+geo-types = { version = "0.7.0" }
 gdal-sys = { path = "gdal-sys", version = "^0.3"}
-num-traits = "0.2"
 ndarray = {version = "0.14", optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/src/vector/geo_to_gdal.rs
+++ b/src/vector/geo_to_gdal.rs
@@ -1,11 +1,11 @@
 use crate::errors::*;
 use crate::vector::{Geometry, ToGdal};
 use gdal_sys::OGRwkbGeometryType;
-use num_traits::Float;
+use geo_types::CoordFloat;
 
 impl<T> ToGdal for geo_types::Point<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbPoint)?;
@@ -23,7 +23,7 @@ where
 
 impl<T> ToGdal for geo_types::MultiPoint<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbMultiPoint)?;
@@ -40,7 +40,7 @@ fn geometry_with_points<T>(
     points: &geo_types::LineString<T>,
 ) -> Result<Geometry>
 where
-    T: Float,
+    T: CoordFloat,
 {
     let mut geom = Geometry::empty(wkb_type)?;
     let &geo_types::LineString(ref linestring) = points;
@@ -58,7 +58,7 @@ where
 
 impl<T> ToGdal for geo_types::Line<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbLineString)?;
@@ -82,7 +82,7 @@ where
 
 impl<T> ToGdal for geo_types::LineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         geometry_with_points(OGRwkbGeometryType::wkbLineString, self)
@@ -91,7 +91,7 @@ where
 
 impl<T> ToGdal for geo_types::MultiLineString<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbMultiLineString)?;
@@ -105,7 +105,7 @@ where
 
 impl<T> ToGdal for geo_types::Polygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbPolygon)?;
@@ -127,7 +127,7 @@ where
 
 impl<T> ToGdal for geo_types::MultiPolygon<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbMultiPolygon)?;
@@ -141,7 +141,7 @@ where
 
 impl<T> ToGdal for geo_types::GeometryCollection<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         let mut geom = Geometry::empty(OGRwkbGeometryType::wkbGeometryCollection)?;
@@ -155,7 +155,7 @@ where
 
 impl<T> ToGdal for geo_types::Rect<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         self.to_polygon().to_gdal()
@@ -164,7 +164,7 @@ where
 
 impl<T> ToGdal for geo_types::Triangle<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         self.to_polygon().to_gdal()
@@ -173,7 +173,7 @@ where
 
 impl<T> ToGdal for geo_types::Geometry<T>
 where
-    T: Float,
+    T: CoordFloat,
 {
     fn to_gdal(&self) -> Result<Geometry> {
         match *self {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

geo-types <T> must now support Debug. Rather than change all the `num_traits:Float` to `num_traits::Float + Debug`, I've leveraged the new `geo_types::CoordFloat` to the same effect. Consequently, we no longer need to explicitly depend on num_traits.

