### PR TITLE
conventional rust naming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,8 @@
 * Add basic support to read overviews
 * BREAKING: update geo-types to 0.7.0. geo-types Coordinate<T> now implement `Debug`
   * <https://github.com/georust/gdal/pull/146>
+* Deprecated `SpatialRef::get_axis_mapping_strategy` - migrate to
+  `SpatialRef::axis_mapping_strategy` instead.
 
 ## 0.7.1
 * fix docs.rs build for gdal-sys

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -315,7 +315,7 @@ impl SpatialRef {
     }
 
     #[cfg(major_ge_3)]
-    pub fn get_name(&self) -> Result<String> {
+    pub fn name(&self) -> Result<String> {
         let c_ptr = unsafe { gdal_sys::OSRGetName(self.0) };
         if c_ptr.is_null() {
             return Err(_last_null_pointer_err("OSRGetName"));
@@ -323,7 +323,7 @@ impl SpatialRef {
         Ok(_string(c_ptr))
     }
 
-    pub fn get_angular_units_name(&self) -> Result<String> {
+    pub fn angular_units_name(&self) -> Result<String> {
         let mut c_ptr = ptr::null_mut();
         unsafe { gdal_sys::OSRGetAngularUnits(self.0, &mut c_ptr) };
         if c_ptr.is_null() {
@@ -332,11 +332,11 @@ impl SpatialRef {
         Ok(_string(c_ptr))
     }
 
-    pub fn get_angular_units(&self) -> f64 {
+    pub fn angular_units(&self) -> f64 {
         unsafe { gdal_sys::OSRGetAngularUnits(self.0, ptr::null_mut()) }
     }
 
-    pub fn get_linear_units_name(&self) -> Result<String> {
+    pub fn linear_units_name(&self) -> Result<String> {
         let mut c_ptr = ptr::null_mut();
         unsafe { gdal_sys::OSRGetLinearUnits(self.0, &mut c_ptr) };
         if c_ptr.is_null() {
@@ -345,7 +345,7 @@ impl SpatialRef {
         Ok(_string(c_ptr))
     }
 
-    pub fn get_linear_units(&self) -> f64 {
+    pub fn linear_units(&self) -> f64 {
         unsafe { gdal_sys::OSRGetLinearUnits(self.0, ptr::null_mut()) }
     }
 
@@ -385,7 +385,7 @@ impl SpatialRef {
         unsafe { gdal_sys::OSRIsVertical(self.0) == 1 }
     }
 
-    pub fn get_axis_orientation(&self, target_key: &str, axis: i32) -> Result<AxisOrientationType> {
+    pub fn axis_orientation(&self, target_key: &str, axis: i32) -> Result<AxisOrientationType> {
         let mut orientation = gdal_sys::OGRAxisOrientation::OAO_Other;
         let c_ptr = unsafe {
             gdal_sys::OSRGetAxis(
@@ -406,7 +406,7 @@ impl SpatialRef {
         }
     }
 
-    pub fn get_axis_name(&self, target_key: &str, axis: i32) -> Result<String> {
+    pub fn axis_name(&self, target_key: &str, axis: i32) -> Result<String> {
         // See get_axis_orientation
         let c_ptr = unsafe {
             gdal_sys::OSRGetAxis(
@@ -427,7 +427,7 @@ impl SpatialRef {
     }
 
     #[cfg(all(major_ge_3, minor_ge_1))]
-    pub fn get_axes_count(&self) -> i32 {
+    pub fn axes_count(&self) -> i32 {
         unsafe { gdal_sys::OSRGetAxesCount(self.0) }
     }
 
@@ -439,12 +439,18 @@ impl SpatialRef {
     }
 
     #[cfg(major_ge_3)]
+    #[deprecated(note = "use `axis_mapping_strategy` instead")]
     pub fn get_axis_mapping_strategy(&self) -> gdal_sys::OSRAxisMappingStrategy::Type {
+        self.axis_mapping_strategy()
+    }
+
+    #[cfg(major_ge_3)]
+    pub fn axis_mapping_strategy(&self) -> gdal_sys::OSRAxisMappingStrategy::Type {
         unsafe { gdal_sys::OSRGetAxisMappingStrategy(self.0) }
     }
 
     #[cfg(major_ge_3)]
-    pub fn get_area_of_use(&self) -> Option<AreaOfUse> {
+    pub fn area_of_use(&self) -> Option<AreaOfUse> {
         let mut c_area_name: *const libc::c_char = ptr::null_mut();
         let (mut w_long, mut s_lat, mut e_long, mut n_lat): (f64, f64, f64, f64) =
             (0.0, 0.0, 0.0, 0.0);

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -212,22 +212,22 @@ fn auto_identify() {
 fn axis_mapping_strategy() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
     assert_eq!(
-        spatial_ref.get_axis_mapping_strategy(),
+        spatial_ref.axis_mapping_strategy(),
         gdal_sys::OSRAxisMappingStrategy::OAMS_AUTHORITY_COMPLIANT
     );
     spatial_ref
         .set_axis_mapping_strategy(gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER);
     assert_eq!(
-        spatial_ref.get_axis_mapping_strategy(),
+        spatial_ref.axis_mapping_strategy(),
         gdal_sys::OSRAxisMappingStrategy::OAMS_TRADITIONAL_GIS_ORDER
     );
 }
 
 #[cfg(major_ge_3)]
 #[test]
-fn get_area_of_use() {
+fn area_of_use() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
-    let area_of_use = spatial_ref.get_area_of_use().unwrap();
+    let area_of_use = spatial_ref.area_of_use().unwrap();
     assert_almost_eq(area_of_use.west_lon_degree, -180.0);
     assert_almost_eq(area_of_use.south_lat_degree, -90.0);
     assert_almost_eq(area_of_use.east_lon_degree, 180.0);
@@ -238,7 +238,7 @@ fn get_area_of_use() {
 #[test]
 fn get_name() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
-    let name = spatial_ref.get_name().unwrap();
+    let name = spatial_ref.name().unwrap();
     assert_eq!(name, "WGS 84");
 }
 
@@ -246,18 +246,18 @@ fn get_name() {
 fn get_units_epsg4326() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
 
-    let angular_units_name = spatial_ref.get_angular_units_name().unwrap();
+    let angular_units_name = spatial_ref.angular_units_name().unwrap();
     assert_eq!(angular_units_name.to_lowercase(), "degree");
-    let to_radians = spatial_ref.get_angular_units();
+    let to_radians = spatial_ref.angular_units();
     assert_almost_eq(to_radians, 0.01745329);
 }
 
 #[test]
 fn get_units_epsg2154() {
     let spatial_ref = SpatialRef::from_epsg(2154).unwrap();
-    let linear_units_name = spatial_ref.get_linear_units_name().unwrap();
+    let linear_units_name = spatial_ref.linear_units_name().unwrap();
     assert_eq!(linear_units_name.to_lowercase(), "metre");
-    let to_meters = spatial_ref.get_linear_units();
+    let to_meters = spatial_ref.linear_units();
     assert_almost_eq(to_meters, 1.0);
 }
 
@@ -295,11 +295,11 @@ fn crs_axis() {
     let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
 
     #[cfg(all(major_ge_3, minor_ge_1))]
-    assert_eq!(spatial_ref.get_axes_count(), 2);
+    assert_eq!(spatial_ref.axes_count(), 2);
 
-    let orientation = spatial_ref.get_axis_orientation("GEOGCS", 0).unwrap();
+    let orientation = spatial_ref.axis_orientation("GEOGCS", 0).unwrap();
     assert_eq!(orientation, gdal_sys::OGRAxisOrientation::OAO_North);
-    assert!(spatial_ref.get_axis_name("GEOGCS", 0).is_ok());
-    assert!(spatial_ref.get_axis_name("DO_NO_EXISTS", 0).is_err());
-    assert!(spatial_ref.get_axis_orientation("DO_NO_EXISTS", 0).is_err());
+    assert!(spatial_ref.axis_name("GEOGCS", 0).is_ok());
+    assert!(spatial_ref.axis_name("DO_NO_EXISTS", 0).is_err());
+    assert!(spatial_ref.axis_orientation("DO_NO_EXISTS", 0).is_err());
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Nitpicky follow up to #145. Sorry it didn't occur to me during review! 

Idiomatically, rust API's omit the `get_` prefix from "getters". 

https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter