### PR TITLE
Support extended flags for open_ex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,35 @@
 # Changes
 
 ## Unreleased
+* **Breaking**: Use `DatasetOptions` to pass as `Dataset::open_ex` parameters and
+    add support for extended open flags.
+
+    ```rust
+        use gdal::{ Dataset, DatasetOptions }
+
+        let dataset = Dataset::open_ex(
+            "roads.geojson",
+            DatasetOptions { 
+                open_flags: GdalOpenFlags::GDAL_OF_UPDATE|GdalOpenFlags::GDAL_OF_VECTOR,
+                ..DatasetOptions::default()
+            }
+        )
+        .unwrap();
+    ```
+
+    `GDALAccess` values are supported usinf [`From`] implementation
+
+    ```rust
+        Dataset::open_ex(
+            "roads.geojson",
+            DatasetOptions {
+                open_flags: GDALAccess::GA_Update.into(),
+                ..DatasetOptions::default()
+            },
+        )
+        .unwrap();
+    ```
+
 * Add more functions to SpatialRef implementation
     * <https://github.com/georust/gdal/pull/145>   
 * **Breaking**: Change `Feature::field` return type from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ geo-types = { version = "0.7.0" }
 gdal-sys = { path = "gdal-sys", version = "^0.3"}
 ndarray = {version = "0.14", optional = true }
 chrono = { version = "0.4", optional = true }
+bitflags = "1.2"
 
 [build-dependencies]
 gdal-sys = { path = "gdal-sys", version="^0.3"}


### PR DESCRIPTION
   
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is attempt to fix #154 

This is an api breaking change

This PR allow using `GDAL_OF_XXX` extended flags. 

Implement a `DatasetOptions` to pass to `Dataset::open_ex`

```rust
    use gdal::{ Dataset, DatasetOptions }

    let dataset = Dataset::open_ex(
        "roads.geojson",
        DatasetOptions { 
            open_flags: GdalOpenFlags::GDAL_OF_UPDATE|GdalOpenFlags::GDAL_OF_VECTOR,
            ..DatasetOptions::default()
       }
    )
     .unwrap();
```

    `GDALAccess` values are supported using [`From`] implementation

```rust
    Dataset::open_ex(
        "roads.geojson",
        DatasetOptions {
            open_flags: GDALAccess::GA_Update.into(),
            ..DatasetOptions::default()
        },
    )
    .unwrap();
```

Note that [following this note](https://github.com/georust/gdal/issues/154#issuecomment-770187560)  `GDAL_OF_SHARED` option is removed from the set of allowed option because it subverts the [`Send`] implementation that allow passing the dataset the another thread.

