### PR TITLE
Add missing dataset exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,9 @@ mod utils;
 pub mod vector;
 pub mod version;
 
-pub use dataset::{Dataset, GeoTransform, LayerIterator, Transaction};
+pub use dataset::{
+    Dataset, DatasetOptions, GdalOpenFlags, GeoTransform, LayerIterator, Transaction,
+};
 pub use driver::Driver;
 pub use metadata::Metadata;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

A small fix for https://github.com/georust/gdal/pull/155: as `dataset` is a private module, `dataset::GdalOpenFlagls` and `dataset::DatasetOptions`  must be exported in order to be used because they are required with `open_ex`. 