### PR TITLE
Implement wrapper for OGR_L_TestCapability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased
+* Implement wrapper for `OGR_L_TestCapability`
+    * <https://github.com/georust/gdal/pull/160>
 * **Breaking**: Use `DatasetOptions` to pass as `Dataset::open_ex` parameters and
     add support for extended open flags.
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -13,6 +13,51 @@ use std::{convert::TryInto, ffi::CString, marker::PhantomData};
 
 use crate::errors::*;
 
+/// Layer capabilities, map GDAL defines
+#[allow(non_upper_case_globals)]
+#[allow(non_snake_case)]
+pub mod LayerCaps {
+
+    pub type Type = &'static str;
+
+    /// Layer capability for random read
+    pub const OLCRandomRead: Type = "RandomRead";
+    /// Layer capability for sequential write
+    pub const OLCSequentialWrite: Type = "SequentialWrite";
+    /// Layer capability for random write
+    pub const OLCRandomWrite: Type = "RandomWrite";
+    /// Layer capability for fast spatial filter
+    pub const OLCFastSpatialFilter: Type = "FastSpatialFilter";
+    /// Layer capability for fast feature count retrieval
+    pub const OLCFastFeatureCount: Type = "FastFeatureCount";
+    /// Layer capability for fast extent retrieval
+    pub const OLCFastGetExtent: Type = "FastGetExtent";
+    /// Layer capability for field creation
+    pub const OLCCreateField: Type = "CreateField";
+    /// Layer capability for field deletion
+    pub const OLCDeleteField: Type = "DeleteField";
+    /// Layer capability for field reordering
+    pub const OLCReorderFields: Type = "ReorderFields";
+    /// Layer capability for field alteration
+    pub const OLCAlterFieldDefn: Type = "AlterFieldDefn";
+    /// Layer capability for transactions
+    pub const OLCTransactions: Type = "Transactions";
+    /// Layer capability for feature deletiond
+    pub const OLCDeleteFeature: Type = "DeleteFeature";
+    /// Layer capability for setting next feature index
+    pub const OLCFastSetNextByIndex: Type = "FastSetNextByIndex";
+    /// Layer capability for strings returned with UTF-8 encoding
+    pub const OLCStringsAsUTF8: Type = "StringsAsUTF8";
+    /// Layer capability for field ignoring
+    pub const OLCIgnoreFields: Type = "IgnoreFields";
+    /// Layer capability for geometry field creation
+    pub const OLCCreateGeomField: Type = "CreateGeomField";
+    /// Layer capability for curve geometries support
+    pub const OLCCurveGeometries: Type = "CurveGeometries";
+    /// Layer capability for measured geometries support
+    pub const OLCMeasuredGeometries: Type = "MeasuredGeometries";
+}
+
 /// Layer in a vector dataset
 ///
 /// ```
@@ -99,6 +144,13 @@ impl<'a> Layer<'a> {
     pub fn name(&self) -> String {
         let rv = unsafe { gdal_sys::OGR_L_GetName(self.c_layer) };
         _string(rv)
+    }
+
+    pub fn has_capability(&self, capability: LayerCaps::Type) -> Result<bool> {
+        let rv = unsafe {
+            gdal_sys::OGR_L_TestCapability(self.c_layer, CString::new(capability)?.as_ptr()) == 1
+        };
+        Ok(rv)
     }
 
     pub fn defn(&self) -> &Defn {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -27,7 +27,7 @@ pub use defn::{Defn, Field, FieldIterator};
 pub use feature::{Feature, FieldValue, FieldValueIterator};
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
 pub use geometry::Geometry;
-pub use layer::{FeatureIterator, FieldDefn, Layer};
+pub use layer::{FeatureIterator, FieldDefn, Layer, LayerCaps};
 pub use ops::GeometryIntersection;
 
 use crate::errors::Result;

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -1,5 +1,6 @@
 use super::{
-    Feature, FeatureIterator, FieldValue, Geometry, Layer, OGRFieldType, OGRwkbGeometryType,
+    Feature, FeatureIterator, FieldValue, Geometry, Layer, LayerCaps::*, OGRFieldType,
+    OGRwkbGeometryType,
 };
 use crate::spatial_ref::SpatialRef;
 use crate::{assert_almost_eq, Dataset, Driver};
@@ -61,6 +62,18 @@ fn test_layer_spatial_ref() {
     let layer = ds.layer(0).unwrap();
     let srs = layer.spatial_ref().unwrap();
     assert_eq!(srs.auth_code().unwrap(), 4326);
+}
+
+#[test]
+fn test_layer_capabilities() {
+    let mut ds = Dataset::open(fixture!("roads.geojson")).unwrap();
+    let layer = ds.layer(0).unwrap();
+
+    assert_eq!(layer.has_capability(OLCFastSpatialFilter).unwrap(), false);
+    assert_eq!(layer.has_capability(OLCFastFeatureCount).unwrap(), true);
+    assert_eq!(layer.has_capability(OLCFastGetExtent).unwrap(), false);
+    assert_eq!(layer.has_capability(OLCRandomRead).unwrap(), true);
+    assert_eq!(layer.has_capability(OLCStringsAsUTF8).unwrap(), true);
 }
 
 fn ds_with_layer<F>(ds_name: &str, layer_name: &str, f: F)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

* Map `OLCxxx GDAL` preprocessor defines to  `LayerCaps::OLCxxx` constants.
* Add wrapper for `OGR_L_TestGetCapability` as `Layer::test_capability(&self,  capability: LayerCaps::Type) -> Result<bool>`
