### PR TITLE
Add geos predicat methods for `Geometry`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased
+* Add GEOS based predicate methods
+    Add build test for GEOS availability
 * **Breaking**: Upgrade to `ndarray 0.15`
     * <https://github.com/georust/gdal/pull/175>
 * Implement wrapper for `OGR_L_TestCapability`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bitflags = "1.2"
 [build-dependencies]
 gdal-sys = { path = "gdal-sys", version="^0.3"}
 semver = "0.11"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.1"


### PR DESCRIPTION
 - [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

* Add geos based predicat methods for `Geometry`:
   - `intersects`
   - `disjoint`
   - `touches`
   - `crosses`
   - `within`
   - `contains`
   - `overlaps`

* Add build test for geos availability: `have_geos`

