### PR TITLE
Replace create_layer arguments list by LayerOptions struct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,30 @@
 - Fixed memory leak in `Geometry::from_wkt`
   - <https://github.com/georust/gdal/pull/172>
 
+- **Breaking**: Changed `Dataset::create_layer` to take a new `LayerOptions`
+  struct instead of separate arguments.
+
+  Before:
+
+  ```rust
+  ds.create_layer("roads", None, wkbLineString)
+  ```
+
+  After (all fields have usable default values):
+
+  ```rust
+  use gdal::LayerOptions;
+  ds.create_layer(LayerOptions {
+    name: "roads",
+    ty: wkbLineString,
+    ..Default::default()
+  });
+  ```
+
+  This change also removed `Dataset::create_layer_blank()`. Use
+  `Dataset::create_layer(Default::default())` instead.
+
+  - <https://github.com/georust/gdal/pull/186>
 
 ## 0.7.1
 

--- a/examples/read_write_ogr.rs
+++ b/examples/read_write_ogr.rs
@@ -19,7 +19,7 @@ fn run() -> Result<()> {
     let _ = fs::remove_file(&path);
     let drv = Driver::get("ESRI Shapefile")?;
     let mut ds = drv.create_vector_only(path.to_str().unwrap())?;
-    let lyr = ds.create_layer_blank()?;
+    let lyr = ds.create_layer(Default::default())?;
 
     // Copy the origin layer shema to the destination layer:
     for fd in &fields_defn {

--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -16,7 +16,7 @@ fn run() -> gdal::errors::Result<()> {
     let _ = std::fs::remove_file(&path);
     let drv = Driver::get("GeoJSON")?;
     let mut ds = drv.create_vector_only(path.to_str().unwrap())?;
-    let lyr = ds.create_layer_blank()?;
+    let lyr = ds.create_layer(Default::default())?;
 
     // Copy the origin layer shema to the destination layer:
     for field in layer_a.defn().fields() {

--- a/examples/write_ogr.rs
+++ b/examples/write_ogr.rs
@@ -10,7 +10,7 @@ fn example_1() -> Result<()> {
     let drv = Driver::get("GeoJSON")?;
     let mut ds = drv.create_vector_only(path.to_str().unwrap())?;
 
-    let lyr = ds.create_layer_blank()?;
+    let lyr = ds.create_layer(Default::default())?;
 
     let field_defn = FieldDefn::new("Name", OGRFieldType::OFTString)?;
     field_defn.set_width(80);
@@ -54,7 +54,7 @@ fn example_2() -> Result<()> {
     let _ = fs::remove_file(&path);
     let driver = Driver::get("GeoJSON")?;
     let mut ds = driver.create_vector_only(path.to_str().unwrap())?;
-    let mut layer = ds.create_layer_blank()?;
+    let mut layer = ds.create_layer(Default::default())?;
 
     layer.create_defn_fields(&[
         ("Name", OGRFieldType::OFTString),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod vector;
 pub mod version;
 
 pub use dataset::{
-    Dataset, DatasetOptions, GdalOpenFlags, GeoTransform, LayerIterator, Transaction,
+    Dataset, DatasetOptions, GdalOpenFlags, GeoTransform, LayerIterator, LayerOptions, Transaction,
 };
 pub use driver::Driver;
 pub use metadata::Metadata;

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -471,7 +471,7 @@ mod tests {
             let mut ds = driver
                 .create_vector_only(&fixture!("output.geojson").to_string_lossy())
                 .unwrap();
-            let mut layer = ds.create_layer_blank().unwrap();
+            let mut layer = ds.create_layer(Default::default()).unwrap();
             layer
                 .create_defn_fields(&[
                     ("Name", OGRFieldType::OFTString),


### PR DESCRIPTION
This adds support for driver-specific `name=value` pairs while also
simplifying the API a bit.

Removes `create_layer_blank` because it seems to serve only niche use
cases and can easily be replaced by `create_layer(Default::default())`.

Fixes #185.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

