### PR TITLE
Add raster creation options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,18 +2,14 @@
 
 ## Unreleased
 
-- Add support to define creation options for raster datasets. To support this a new struct to store a creation option key and value pair  (`RasterCreationOption`) and and function (`driver.create_with_band_type_with_options()`) were created.
+- Add support for raster dataset creation options. A new struct (`RasterCreationOption`) and function (`driver.create_with_band_type_with_options()`) are now available for this.
 
 ```rust
     let driver = Driver::get("GTiff").unwrap();
-    let options = vec![RasterCreationOption{key:"COMPRESS", value:"LZW"} ,
-                       RasterCreationOption{key:"TILED", value: "YES"}] ;
+    let options = [RasterCreationOption{key:"COMPRESS", value:"LZW"} ,
+                   RasterCreationOption{key:"TILED", value: "YES"}] ;
     let mut dataset = driver
-          .create_with_band_type_with_options::<u8>("testing.tif",
-             2048,
-             2048,
-             1,
-             options)
+          .create_with_band_type_with_options::<u8>("testing.tif",2048,2048,1,&options)
           .unwrap();
 ```
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Add support for raster dataset creation options. A new struct (`RasterCreationOption`) and function (`driver.create_with_band_type_with_options()`) are now available for this.
 
+  - <https://github.com/georust/gdal/pull/193>
+
 ```rust
 let driver = Driver::get("GTiff").unwrap();
 let options = &[
@@ -19,6 +21,7 @@ let options = &[
 let mut dataset = driver
     .create_with_band_type_with_options::<u8>("testing.tif", 2048, 2048, 1, options)
     .unwrap();
+```
 
 - **Breaking**: Add support to select a resampling algorithm when reading a raster
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- Add support to define creation options for raster datasets. To support this a new struct to store a creation option key and value pair  (`RasterCreationOption`) and and function (`driver.create_with_band_type_with_options()`) were created.
+
+```rust
+    let driver = Driver::get("GTiff").unwrap();
+    let options = vec![RasterCreationOption{key:"COMPRESS", value:"LZW"} ,
+                       RasterCreationOption{key:"TILED", value: "YES"}] ;
+    let mut dataset = driver
+          .create_with_band_type_with_options::<u8>("testing.tif",
+             2048,
+             2048,
+             1,
+             options)
+          .unwrap();
+```
+
 - **Breaking**: Add support to select a resampling algorithm when reading a raster
 
   - <https://github.com/georust/gdal/pull/141>

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -90,22 +90,8 @@ impl Driver {
         size_y: isize,
         bands: isize,
     ) -> Result<Dataset> {
-        let c_filename = CString::new(filename)?;
-        let c_dataset = unsafe {
-            gdal_sys::GDALCreate(
-                self.c_driver,
-                c_filename.as_ptr(),
-                size_x as c_int,
-                size_y as c_int,
-                bands as c_int,
-                T::gdal_type(),
-                null_mut(),
-            )
-        };
-        if c_dataset.is_null() {
-            return Err(_last_null_pointer_err("GDALCreate"));
-        };
-        Ok(unsafe { Dataset::from_c_dataset(c_dataset) })
+        let options = [];
+        self.create_with_band_type_with_options::<T>(filename, size_x, size_y, bands, &options)
     }
 
     pub fn create_with_band_type_with_options<T: GdalType>(

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -34,10 +34,10 @@ extern "C" {
         pszName: *const libc::c_char,
         pszValue: *const libc::c_char) -> *mut *mut libc::c_char;
 }
-
+#[derive(Debug)]
 pub struct RasterCreationOption<'a>{
-    key : &'a str,
-    value : &'a str,
+    pub key : &'a str,
+    pub value : &'a str,
 }
 
 impl Driver {
@@ -76,6 +76,7 @@ impl Driver {
         let rv = unsafe { gdal_sys::GDALGetDriverLongName(self.c_driver) };
         _string(rv)
     }
+
 
     pub fn create(
         &self,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -114,7 +114,7 @@ impl Driver {
         size_x: isize,
         size_y: isize,
         bands: isize,
-        options: Vec<RasterCreationOption>,
+        options: &[RasterCreationOption],
     ) -> Result<Dataset> {
         // process options:
         let mut options_c = null_mut();

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -116,7 +116,6 @@ impl Driver {
         bands: isize,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
-        // process options:
         let mut options_c = null_mut();
         for option in options {
             let psz_name = CString::new(option.key)?;

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -36,7 +36,6 @@ extern "C" {
     ) -> *mut *mut libc::c_char;
 }
 
-
 impl Driver {
     pub fn get(name: &str) -> Result<Driver> {
         _register_drivers();

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -8,5 +8,11 @@ pub use rasterband::{Buffer, ByteBuffer, ColorInterpretation, RasterBand};
 pub use types::{GDALDataType, GdalType};
 pub use warp::reproject;
 
+#[derive(Debug)]
+pub struct RasterCreationOption<'a> {
+    pub key: &'a str,
+    pub value: &'a str,
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -252,7 +252,8 @@ fn test_create_with_band_type_with_options() {
         
         ] ;
 
-    let dataset = driver.create_with_band_type_with_options::<u8>("/tmp/test.tif",
+    let tmp_filename = "/tmp/test.tif";
+    let dataset = driver.create_with_band_type_with_options::<u8>(tmp_filename,
                      256,
                       256,
                       1,
@@ -263,12 +264,13 @@ fn test_create_with_band_type_with_options() {
     let block_size = rasterband.block_size();
     assert_eq!(block_size, (128,64));
 
-    
+    drop(dataset);
+    let dataset = Dataset::open(Path::new(tmp_filename)).unwrap();
     let key = "INTERLEAVE";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, Some(String::from("BAND")));
-    let key = "COMPRESS";
+    let key = "COMPRESSION";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, Some(String::from("LZW")));   

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -249,6 +249,7 @@ fn test_create_with_band_type_with_options() {
         RasterCreationOption{key:"BLOCKYSIZE", value: "64"},
         RasterCreationOption{key:"COMPRESS", value:"LZW"} ,
         RasterCreationOption{key:"INTERLEAVE", value:"BAND"} ,
+        
         ] ;
 
     let dataset = driver.create_with_band_type_with_options::<u8>("/tmp/test.tif",
@@ -267,26 +268,11 @@ fn test_create_with_band_type_with_options() {
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, Some(String::from("BAND")));
-
     let key = "COMPRESS";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
     assert_eq!(meta, Some(String::from("LZW")));   
-    
-    // > gdalinfo /tmp/test.tif 
-    // Driver: GTiff/GeoTIFF
-    // Files: /tmp/test.tif
-    // Size is 256, 256
-    // Image Structure Metadata:
-    //   COMPRESSION=LZW
-    //   INTERLEAVE=BAND
-    // Corner Coordinates:
-    // Upper Left  (    0.0,    0.0)
-    // Lower Left  (    0.0,  256.0)
-    // Upper Right (  256.0,    0.0)
-    // Lower Right (  256.0,  256.0)
-    // Center      (  128.0,  128.0)
-    // Band 1 Block=128x64 Type=Byte, ColorInterp=Gray
+
         }
 
 #[test]

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -1,8 +1,7 @@
 use crate::dataset::Dataset;
-use crate::driver::RasterCreationOption;
 use crate::metadata::Metadata;
 use crate::raster::rasterband::ResampleAlg;
-use crate::raster::{ByteBuffer, ColorInterpretation};
+use crate::raster::{ByteBuffer, ColorInterpretation, RasterCreationOption};
 use crate::Driver;
 use gdal_sys::GDALDataType;
 use std::path::Path;
@@ -243,7 +242,7 @@ fn test_create_with_band_type() {
 #[test]
 fn test_create_with_band_type_with_options() {
     let driver = Driver::get("GTiff").unwrap();
-    let options = vec![
+    let options = [
         RasterCreationOption {
             key: "TILED",
             value: "YES",
@@ -268,7 +267,7 @@ fn test_create_with_band_type_with_options() {
 
     let tmp_filename = "/tmp/test.tif";
     let dataset = driver
-        .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, options)
+        .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
         .unwrap();
 
     let rasterband = dataset.rasterband(1).unwrap();

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -266,15 +266,16 @@ fn test_create_with_band_type_with_options() {
     ];
 
     let tmp_filename = "/tmp/test.tif";
-    let dataset = driver
-        .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
-        .unwrap();
+    {
+        let dataset = driver
+            .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
+            .unwrap();
+    
+        let rasterband = dataset.rasterband(1).unwrap();
+        let block_size = rasterband.block_size();
+        assert_eq!(block_size, (128, 64));
+    }
 
-    let rasterband = dataset.rasterband(1).unwrap();
-    let block_size = rasterband.block_size();
-    assert_eq!(block_size, (128, 64));
-
-    drop(dataset);
     let dataset = Dataset::open(Path::new(tmp_filename)).unwrap();
     let key = "INTERLEAVE";
     let domain = "IMAGE_STRUCTURE";

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -244,25 +244,36 @@ fn test_create_with_band_type() {
 fn test_create_with_band_type_with_options() {
     let driver = Driver::get("GTiff").unwrap();
     let options = vec![
-        RasterCreationOption{key:"TILED", value: "YES"},
-        RasterCreationOption{key:"BLOCKXSIZE", value: "128"},
-        RasterCreationOption{key:"BLOCKYSIZE", value: "64"},
-        RasterCreationOption{key:"COMPRESS", value:"LZW"} ,
-        RasterCreationOption{key:"INTERLEAVE", value:"BAND"} ,
-        
-        ] ;
+        RasterCreationOption {
+            key: "TILED",
+            value: "YES",
+        },
+        RasterCreationOption {
+            key: "BLOCKXSIZE",
+            value: "128",
+        },
+        RasterCreationOption {
+            key: "BLOCKYSIZE",
+            value: "64",
+        },
+        RasterCreationOption {
+            key: "COMPRESS",
+            value: "LZW",
+        },
+        RasterCreationOption {
+            key: "INTERLEAVE",
+            value: "BAND",
+        },
+    ];
 
     let tmp_filename = "/tmp/test.tif";
-    let dataset = driver.create_with_band_type_with_options::<u8>(tmp_filename,
-                     256,
-                      256,
-                      1,
-                     options).unwrap();
+    let dataset = driver
+        .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, options)
+        .unwrap();
 
-    
     let rasterband = dataset.rasterband(1).unwrap();
     let block_size = rasterband.block_size();
-    assert_eq!(block_size, (128,64));
+    assert_eq!(block_size, (128, 64));
 
     drop(dataset);
     let dataset = Dataset::open(Path::new(tmp_filename)).unwrap();
@@ -273,9 +284,8 @@ fn test_create_with_band_type_with_options() {
     let key = "COMPRESSION";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
-    assert_eq!(meta, Some(String::from("LZW")));   
-
-        }
+    assert_eq!(meta, Some(String::from("LZW")));
+}
 
 #[test]
 fn test_create_copy() {

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -280,11 +280,11 @@ fn test_create_with_band_type_with_options() {
     let key = "INTERLEAVE";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
-    assert_eq!(meta, Some(String::from("BAND")));
+    assert_eq!(meta.as_deref(), Some("BAND"));
     let key = "COMPRESSION";
     let domain = "IMAGE_STRUCTURE";
     let meta = dataset.metadata_item(key, domain);
-    assert_eq!(meta, Some(String::from("LZW")));
+    assert_eq!(meta.as_deref(), Some("LZW"));
 }
 
 #[test]

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -270,7 +270,6 @@ fn test_create_with_band_type_with_options() {
         let dataset = driver
             .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
             .unwrap();
-
         let rasterband = dataset.rasterband(1).unwrap();
         let block_size = rasterband.block_size();
         assert_eq!(block_size, (128, 64));

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -270,7 +270,7 @@ fn test_create_with_band_type_with_options() {
         let dataset = driver
             .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
             .unwrap();
-    
+
         let rasterband = dataset.rasterband(1).unwrap();
         let block_size = rasterband.block_size();
         assert_eq!(block_size, (128, 64));


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Please review the additions I made (related to #190 ).

Also, I think there may be a bug in `dataset.metadata_item();` which makes the test ` test_create_with_band_type_with_options() ` fail, since I can see the COMPRESSION field in the image structure metadata when using `gdalinfo`. Or am I missing something?

gdalinfo output:
```bash
Files: /tmp/test.tif
Size is 256, 256
Image Structure Metadata:
  COMPRESSION=LZW
  INTERLEAVE=BAND
Corner Coordinates:
Upper Left  (    0.0,    0.0)
Lower Left  (    0.0,  256.0)
Upper Right (  256.0,    0.0)
Lower Right (  256.0,  256.0)
Center      (  128.0,  128.0)
Band 1 Block=128x64 Type=Byte, ColorInterp=Gray
```

test error:
```
thread 'raster::tests::test_create_with_band_type_with_options' panicked at 'assertion failed: `(left == right)`
  left: `None`,
 right: `Some("LZW")`', src/raster/tests.rs:273:5
```