### PR TITLE
Add ResampleAlg to raster pub exports (fixes #188)

### DIFF
--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -4,7 +4,7 @@ mod rasterband;
 mod types;
 mod warp;
 
-pub use rasterband::{Buffer, ByteBuffer, ColorInterpretation, RasterBand};
+pub use rasterband::{Buffer, ByteBuffer, ColorInterpretation, RasterBand, ResampleAlg};
 pub use types::{GDALDataType, GdalType};
 pub use warp::reproject;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

As mentioned in #188, ResampleAlg was not included in the public exports of the raster module (my bad!).

This PR should fix that.