### PR TITLE
OGR Layer: Set Attribute Filter & Set Spatial Filter as Rectangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -170,8 +170,13 @@ let mut dataset = driver
 
   - <https://github.com/georust/gdal/pull/186>
 
-  - Wrapper functions for `OGR_F_GetFieldAs…` methods
-    - <https://github.com/georust/gdal/pull/199>
+- Wrapper functions for `OGR_F_GetFieldAs…` methods
+
+  - <https://github.com/georust/gdal/pull/199>
+
+- Wrapper functions for `OGR_L_SetAttributeFilter` and `OGR_L_SetSpatialFilterRect`
+
+  - <https://github.com/georust/gdal/pull/200>
 
 ## 0.7.1
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -334,15 +334,11 @@ impl<'a> Layer<'a> {
     /// Set a new attribute query that restricts features when using the feature iterator.
     ///
     /// Parameters:
-    /// - `psz_query` `Some(query)` in restricted SQL WHERE format, or `None` to clear the current query.
+    /// - `psz_query` in restricted SQL WHERE format
     ///
-    pub fn set_attribute_filter(&self, psz_query: Option<&str>) -> Result<()> {
-        let rv = if let Some(query) = psz_query {
-            let c_str = CString::new(query)?;
-            unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) }
-        } else {
-            unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, std::ptr::null()) }
-        };
+    pub fn set_attribute_filter(&self, psz_query: &str) -> Result<()> {
+        let c_str = CString::new(psz_query)?;
+        let rv = unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) };
 
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {
@@ -352,6 +348,13 @@ impl<'a> Layer<'a> {
         }
 
         Ok(())
+    }
+
+    /// Clear the attribute filter set on this layer
+    pub fn clear_attribute_filter(&self) {
+        unsafe {
+            gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, null_mut());
+        }
     }
 }
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -339,10 +339,10 @@ impl<'a> Layer<'a> {
     /// Set a new attribute query that restricts features when using the feature iterator.
     ///
     /// Parameters:
-    /// - `psz_query` in restricted SQL WHERE format
+    /// - `query` in restricted SQL WHERE format
     ///
-    pub fn set_attribute_filter(&self, psz_query: &str) -> Result<()> {
-        let c_str = CString::new(psz_query)?;
+    pub fn set_attribute_filter(&self, query: &str) -> Result<()> {
+        let c_str = CString::new(query)?;
         let rv = unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) };
 
         if rv != OGRErr::OGRERR_NONE {

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -164,6 +164,11 @@ impl<'a> Layer<'a> {
         unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer, geometry.c_geometry()) };
     }
 
+    /// Set a spatial rectangle filter on this layer by specifying the bounds of a rectangle.
+    pub fn set_spatial_filter_rect(&mut self, min_x: f64, min_y: f64, max_x: f64, max_y: f64) {
+        unsafe { gdal_sys::OGR_L_SetSpatialFilterRect(self.c_layer, min_x, min_y, max_x, max_y) };
+    }
+
     /// Clear spatial filters set on this layer.
     pub fn clear_spatial_filter(&mut self) {
         unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer, null_mut()) };

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -330,6 +330,29 @@ impl<'a> Layer<'a> {
             gdal_sys::OGR_L_ResetReading(self.c_layer);
         }
     }
+
+    /// Set a new attribute query that restricts features when using the feature iterator.
+    ///
+    /// Parameters:
+    /// - `psz_query` `Some(query)` in restricted SQL WHERE format, or `None` to clear the current query.
+    ///
+    pub fn set_attribute_filter(&self, psz_query: Option<&str>) -> Result<()> {
+        let rv = if let Some(query) = psz_query {
+            let c_str = CString::new(query)?;
+            unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) }
+        } else {
+            unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, std::ptr::null()) }
+        };
+
+        if rv != OGRErr::OGRERR_NONE {
+            return Err(GdalError::OgrError {
+                err: rv,
+                method_name: "OGR_L_SetAttributeFilter",
+            });
+        }
+
+        Ok(())
+    }
 }
 
 pub struct FeatureIterator<'a> {

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -690,4 +690,38 @@ mod tests {
     //         }
     //     });
     // }
+
+    #[test]
+    fn test_set_attribute_filter() {
+        with_layer("roads.geojson", |mut layer| {
+            // check number without calling any function
+            assert_eq!(layer.features().count(), 21);
+
+            // check if resetting does not corrupt anything
+            layer.set_attribute_filter(None).unwrap();
+            assert_eq!(layer.features().count(), 21);
+
+            // apply actual filter
+            layer
+                .set_attribute_filter(Some("highway = 'primary'"))
+                .unwrap();
+
+            assert_eq!(layer.features().count(), 1);
+            assert_eq!(
+                layer
+                    .features()
+                    .next()
+                    .unwrap()
+                    .field_as_string_by_name("highway")
+                    .unwrap()
+                    .unwrap(),
+                "primary"
+            );
+
+            // reset and check again
+            layer.set_attribute_filter(None).unwrap();
+
+            assert_eq!(layer.features().count(), 21);
+        });
+    }
 }

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -573,6 +573,10 @@ mod tests {
 
         layer.clear_spatial_filter();
         assert_eq!(layer.features().count(), 21);
+
+        // test filter as rectangle
+        layer.set_spatial_filter_rect(26.1017, 44.4297, 26.1025, 44.4303);
+        assert_eq!(layer.features().count(), 7);
     }
 
     #[test]

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -697,14 +697,12 @@ mod tests {
             // check number without calling any function
             assert_eq!(layer.features().count(), 21);
 
-            // check if resetting does not corrupt anything
-            layer.set_attribute_filter(None).unwrap();
+            // check if clearing does not corrupt anything
+            layer.clear_attribute_filter();
             assert_eq!(layer.features().count(), 21);
 
             // apply actual filter
-            layer
-                .set_attribute_filter(Some("highway = 'primary'"))
-                .unwrap();
+            layer.set_attribute_filter("highway = 'primary'").unwrap();
 
             assert_eq!(layer.features().count(), 1);
             assert_eq!(
@@ -718,10 +716,19 @@ mod tests {
                 "primary"
             );
 
-            // reset and check again
-            layer.set_attribute_filter(None).unwrap();
+            // clearing and check again
+            layer.clear_attribute_filter();
 
             assert_eq!(layer.features().count(), 21);
+
+            // force error
+            assert_eq!(
+                layer.set_attribute_filter("foo = bar"),
+                Err(GdalError::OgrError {
+                    err: gdal_sys::OGRErr::OGRERR_CORRUPT_DATA,
+                    method_name: "OGR_L_SetAttributeFilter",
+                })
+            );
         });
     }
 }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've added two new functions to the OGR layer wrapper that call…
 * OGR_L_SetAttributeFilter
 * OGR_L_SetSpatialFilterRect

I've also added tests so that we can see that they work.