### PR TITLE
Wrappers for `CPLSetThreadLocalConfigOption` and `CPLGetThreadLocalConfigOption`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -178,6 +178,8 @@ let mut dataset = driver
 
   - <https://github.com/georust/gdal/pull/200>
 
+- Wrappers for `CPLSetThreadLocalConfigOption` and `CPLGetThreadLocalConfigOption`
+
 ## 0.7.1
 
 - fix docs.rs build for gdal-sys

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,8 @@ let mut dataset = driver
 
 - Wrappers for `CPLSetThreadLocalConfigOption` and `CPLGetThreadLocalConfigOption`
 
+  - <https://github.com/georust/gdal/pull/201>
+
 ## 0.7.1
 
 - fix docs.rs build for gdal-sys

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,48 @@ pub fn clear_config_option(key: &str) -> Result<()> {
     Ok(())
 }
 
+/// Set a GDAL library configuration option
+/// with **thread local** scope
+///
+/// Refer to [GDAL `ConfigOptions`](https://trac.osgeo.org/gdal/wiki/ConfigOptions) for
+/// a full list of options.
+///
+pub fn set_thread_local_config_option(key: &str, value: &str) -> Result<()> {
+    let c_key = CString::new(key.as_bytes())?;
+    let c_val = CString::new(value.as_bytes())?;
+    unsafe {
+        gdal_sys::CPLSetThreadLocalConfigOption(c_key.as_ptr(), c_val.as_ptr());
+    };
+    Ok(())
+}
+
+/// Get the value of a GDAL library configuration option
+/// with **thread local** scope
+///
+/// If the config option specified by `key` is not found, the value passed in the `default` paramter is returned.
+///
+/// Refer to [GDAL `ConfigOptions`](https://trac.osgeo.org/gdal/wiki/ConfigOptions) for
+/// a full list of options.
+pub fn get_thread_local_config_option(key: &str, default: &str) -> Result<String> {
+    let c_key = CString::new(key.as_bytes())?;
+    let c_default = CString::new(default.as_bytes())?;
+    let rv = unsafe { gdal_sys::CPLGetThreadLocalConfigOption(c_key.as_ptr(), c_default.as_ptr()) };
+    Ok(_string(rv))
+}
+
+/// Clear the value of a GDAL library configuration option
+/// with **thread local** scope
+///
+/// Refer to [GDAL `ConfigOptions`](https://trac.osgeo.org/gdal/wiki/ConfigOptions) for
+/// a full list of options.
+pub fn clear_thread_local_config_option(key: &str) -> Result<()> {
+    let c_key = CString::new(key.as_bytes())?;
+    unsafe {
+        gdal_sys::CPLSetThreadLocalConfigOption(c_key.as_ptr(), ::std::ptr::null());
+    };
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,6 +141,63 @@ mod tests {
             "256"
         );
         assert!(clear_config_option("TEST_OPTION").is_ok());
+        assert_eq!(
+            get_config_option("TEST_OPTION", "DEFAULT").unwrap_or_else(|_| "".to_string()),
+            "DEFAULT"
+        );
+    }
+
+    #[test]
+    fn test_set_get_option_thread_local() {
+        assert!(set_thread_local_config_option("GDAL_CACHEMAX", "128").is_ok());
+
+        assert_eq!(
+            get_thread_local_config_option("GDAL_CACHEMAX", "").unwrap_or_else(|_| "".to_string()),
+            "128"
+        );
+        // test override for global getter
+        assert_eq!(
+            get_config_option("GDAL_CACHEMAX", "").unwrap_or_else(|_| "".to_string()),
+            "128"
+        );
+
+        assert_eq!(
+            get_thread_local_config_option("NON_EXISTANT_OPTION", "DEFAULT_VALUE")
+                .unwrap_or_else(|_| "".to_string()),
+            "DEFAULT_VALUE"
+        );
+    }
+
+    #[test]
+    fn test_set_option_with_embedded_nul_thread_local() {
+        assert!(set_thread_local_config_option("f\0oo", "valid").is_err());
+        assert!(set_thread_local_config_option("foo", "in\0valid").is_err());
+        assert!(set_thread_local_config_option("xxxf\0oo", "in\0valid").is_err());
+    }
+
+    #[test]
+    fn test_clear_option_thread_local() {
+        assert!(set_thread_local_config_option("TEST_OPTION", "256").is_ok());
+
+        assert_eq!(
+            get_thread_local_config_option("TEST_OPTION", "DEFAULT")
+                .unwrap_or_else(|_| "".to_string()),
+            "256"
+        );
+        // test override for global getter
+        assert_eq!(
+            get_config_option("TEST_OPTION", "DEFAULT").unwrap_or_else(|_| "".to_string()),
+            "256"
+        );
+
+        assert!(clear_thread_local_config_option("TEST_OPTION").is_ok());
+
+        assert_eq!(
+            get_thread_local_config_option("TEST_OPTION", "DEFAULT")
+                .unwrap_or_else(|_| "".to_string()),
+            "DEFAULT"
+        );
+        // test override for global getter
         assert_eq!(
             get_config_option("TEST_OPTION", "DEFAULT").unwrap_or_else(|_| "".to_string()),
             "DEFAULT"


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've added wrappers for `CPLSetThreadLocalConfigOption` and `CPLGetThreadLocalConfigOption` the same way they are already there for the global config.