### PR TITLE
set_attribute_filter shouild take &mut self

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Make `set_attribute_filter` and `clear_attribute_filter` take `&mut self`
+- **Breaking**: Make `set_attribute_filter` and `clear_attribute_filter` take `&mut self`
   - <https://github.com/georust/gdal/pull/209/>
 
 - **Breaking**: Drop pre-build bindings for GDAL versions < 2.4. The bindgen feature can be used to generate bindings for older versions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Make `set_attribute_filter` and `clear_attribute_filter` take `&mut self`
+  - <https://github.com/georust/gdal/pull/209/>
+
 - **Breaking**: Drop pre-build bindings for GDAL versions < 2.4. The bindgen feature can be used to generate bindings for older versions.
 - Fix memory leaks reported by Valgrind. This required re-generation of the pre-build bindings.
   - <https://github.com/georust/gdal/pull/205>

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -339,10 +339,12 @@ impl<'a> Layer<'a> {
 
     /// Set a new attribute query that restricts features when using the feature iterator.
     ///
+    /// From the GDAL docs: Note that installing a query string will generally result in resetting the current reading position
+    ///
     /// Parameters:
     /// - `query` in restricted SQL WHERE format
     ///
-    pub fn set_attribute_filter(&self, query: &str) -> Result<()> {
+    pub fn set_attribute_filter(&mut self, query: &str) -> Result<()> {
         let c_str = CString::new(query)?;
         let rv = unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) };
 
@@ -357,7 +359,10 @@ impl<'a> Layer<'a> {
     }
 
     /// Clear the attribute filter set on this layer
-    pub fn clear_attribute_filter(&self) {
+    ///
+    /// From the GDAL docs: Note that installing a query string will generally result in resetting the current reading position
+    ///
+    pub fn clear_attribute_filter(&mut self) {
         unsafe {
             gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, null_mut());
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

set_attribute_filter should take &mut self since OGR_L_SetAttributeFilter resets the reading position. 