### PR TITLE
Add set description

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,9 @@ let mut dataset = driver
 
   - <https://github.com/georust/gdal/pull/203>
 
+- Add `set_description` to the `Metadata` trait
+
+
 ## 0.7.1
 
 - fix docs.rs build for gdal-sys

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -198,6 +198,8 @@ let mut dataset = driver
 
 - Add `set_description` to the `Metadata` trait
 
+  - <https://github.com/georust/gdal/pull/212>
+
 
 ## 0.7.1
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -93,4 +93,14 @@ pub trait Metadata: MajorObject {
         }
         Ok(())
     }
+
+    fn set_description(&mut self, description: &str) -> Result<()> {
+        // For Datasets this sets the dataset name; normally
+        // application code should not set the "description" for
+        // GDALDatasets. For RasterBands it is actually a description
+        // (if supported) or "".
+        let c_description = CString::new(description.to_owned())?;
+        unsafe { gdal_sys::GDALSetDescription(self.gdal_object_ptr(), c_description.as_ptr()) };
+        Ok(())
+    }
 }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -220,6 +220,19 @@ fn test_set_metadata_item() {
 }
 
 #[test]
+fn test_set_description() {
+    let driver = Driver::get("MEM").unwrap();
+    let dataset = driver.create("", 1, 1, 1).unwrap();
+    let mut band = dataset.rasterband(1).unwrap();
+
+    let description = "A merry and cheerful band description";
+    assert_eq!(band.description().unwrap(), "");
+
+    band.set_description(description).unwrap();
+    assert_eq!(band.description().unwrap(), description);
+}
+
+#[test]
 fn test_create() {
     let driver = Driver::get("MEM").unwrap();
     let dataset = driver.create("", 10, 20, 3).unwrap();


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This is a really simple change that allows users to set descriptions on major GDAL objects; that's mostly useful for RasterBands. If you prefer I could just make this a method on `RasterBand` only instead of more generally making it part of the `Metadata` trait.
