### PR TITLE
Update types to fix build on ppc64le

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update types to fix build on ppc64le.
+  - <https://github.com/georust/gdal/pull/214/>
+
 - Upgrade `semver` to 1.0 and trim gdal version output in `build.rs`.
   - <https://github.com/georust/gdal/pull/211/>
 

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -488,7 +488,7 @@ impl Dataset {
                 c_name.as_ptr(),
                 c_srs,
                 options.ty,
-                c_options_ptr as *mut *mut i8,
+                c_options_ptr as *mut *mut libc::c_char,
             )
         };
         if c_layer.is_null() {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -120,7 +120,7 @@ impl Driver {
                 size_y as c_int,
                 bands as c_int,
                 T::gdal_type(),
-                options_c as *mut *mut i8,
+                options_c as gdal_sys::CSLConstList,
             )
         };
         unsafe { gdal_sys::CSLDestroy(options_c) };


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

`libc::c_char` is a `u8` on `ppc64le`. Using the type definition from `libc` fixes it (maybe for other archs too).