### PR TITLE
Creating error callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -203,6 +203,9 @@ let mut dataset = driver
 
   - <https://github.com/georust/gdal/pull/212>
 
+- Added `set_error_handler` and `remove_error_handler` to the config module that wraps `CPLSetErrorHandlerEx`
+
+  - <https://github.com/georust/gdal/pull/215>
 
 ## 0.7.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ gdal-sys = { path = "gdal-sys", version = "^0.5"}
 ndarray = {version = "0.15", optional = true }
 chrono = { version = "0.4", optional = true }
 bitflags = "1.2"
+lazy_static = "1.3"
 
 [build-dependencies]
 gdal-sys = { path = "gdal-sys", version= "^0.5"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gdal-sys = { path = "gdal-sys", version = "^0.5"}
 ndarray = {version = "0.15", optional = true }
 chrono = { version = "0.4", optional = true }
 bitflags = "1.2"
-lazy_static = "1.3"
+once_cell = "1.8"
 
 [build-dependencies]
 gdal-sys = { path = "gdal-sys", version= "^0.5"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ use libc::{c_char, c_void};
 
 use crate::errors::Result;
 use crate::utils::_string;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::ffi::CString;
 use std::sync::Mutex;
 
@@ -127,10 +127,9 @@ type CallbackType = dyn FnMut(CplErr, i32, &str) + 'static;
 static mut ERROR_CALLBACK: Option<Box<CallbackType>> = None;
 
 type CallbackTypeThreadSafe = dyn FnMut(CplErr, i32, &str) + 'static + Send;
-lazy_static! {
-    static ref ERROR_CALLBACK_THREAD_SAFE: Mutex<Option<Box<CallbackTypeThreadSafe>>> =
-        Mutex::new(None);
-}
+
+static ERROR_CALLBACK_THREAD_SAFE: Lazy<Mutex<Option<Box<CallbackTypeThreadSafe>>>> =
+    Lazy::new(Default::default);
 
 /// Set a custom error handler for GDAL.
 /// Could be overwritten by setting a thread-local error handler.

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,10 @@ pub fn clear_thread_local_config_option(key: &str) -> Result<()> {
 }
 
 type ErrorCallbackType = dyn FnMut(CplErrType, i32, &str) + 'static + Send;
+// We have to double-`Box` the type because we need two things:
+// 1. A stable pointer for moving the data in and out of the `Mutex`. This is done by the outer `Box`.
+// 2. A thin pointer to our Trait-`FnMut`. This is done by the inner (sized) `Box`. We cannot use `*mut dyn FnMut`
+//    (a fat pointer) since we have to cast it from a `*mut c_void`, which is a thin pointer.
 type PinnedErrorCallback = Box<Box<ErrorCallbackType>>;
 
 /// Static variable that holds the current error callback function

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,3 +69,24 @@ pub enum GdalError {
     #[error("Unable to unlink mem file: {file_name}")]
     UnlinkMemFile { file_name: String },
 }
+
+/// A wrapper for [`CPLErr::Type`] that reflects it as an enum
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(C)]
+pub enum CplErrType {
+    None = 0,
+    Debug = 1,
+    Warning = 2,
+    Failure = 3,
+    Fatal = 4,
+}
+
+impl From<CPLErr::Type> for CplErrType {
+    fn from(error_type: CPLErr::Type) -> Self {
+        if error_type > 4 {
+            return Self::None; // fallback type, should not happen
+        }
+
+        unsafe { std::mem::transmute(error_type) }
+    }
+}


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've attached two options for setting up the global GDAL error callback. One is thread-safe and comes with a new dependecy and the other one is not.

The reason for storing the callback in a static variable is that we cannot pass the ownership to GDAL. We can access a generic pointer via the `pUserData` field and cast it to our function type. Therefore, in order not to leak our `FnMut`, we have to store it somehow and drop it later on.

When we decide on which version to use, I can remove the other one and convert the draft to a PR.