### PR TITLE
Support 2D in CoordTransform

### DIFF
--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -2,7 +2,7 @@ use crate::utils::{_last_cpl_err, _last_null_pointer_err, _string};
 use gdal_sys::{self, CPLErr, OGRCoordinateTransformationH, OGRErr, OGRSpatialReferenceH};
 use libc::{c_char, c_int};
 use std::ffi::{CStr, CString};
-use std::ptr;
+use std::ptr::{self, null_mut};
 use std::str::FromStr;
 
 use crate::errors::*;
@@ -42,7 +42,12 @@ impl CoordTransform {
                 nb_coords as c_int,
                 x.as_mut_ptr(),
                 y.as_mut_ptr(),
-                z.as_mut_ptr(),
+                if z.is_empty() {
+                    null_mut()
+                } else {
+                    assert_eq!(nb_coords, z.len());
+                    z.as_mut_ptr()
+                },
             ) == 1
         };
 

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -44,7 +44,7 @@ impl CoordTransform {
         assert_eq!(
             nb_coords,
             y.len(),
-            "transform coordinate slices have different length: {} != {}",
+            "transform coordinate slices have different lengths: {} != {}",
             nb_coords,
             y.len()
         );
@@ -60,7 +60,7 @@ impl CoordTransform {
                     assert_eq!(
                         nb_coords,
                         z.len(),
-                        "transform coordinate slices have different length: {} != {}",
+                        "transform coordinate slices have different lengths: {} != {}",
                         nb_coords,
                         z.len()
                     );

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -33,9 +33,21 @@ impl CoordTransform {
         })
     }
 
+    /// Transform coordinates in place.
+    ///
+    /// # Arguments
+    /// * x - slice of x coordinates
+    /// * y - slice of y coordinates (must match x in length)
+    /// * z - slice of z coordinates, or an empty slice to ignore
     pub fn transform_coords(&self, x: &mut [f64], y: &mut [f64], z: &mut [f64]) -> Result<()> {
         let nb_coords = x.len();
-        assert_eq!(nb_coords, y.len());
+        assert_eq!(
+            nb_coords,
+            y.len(),
+            "transform coordinate slices have different length: {} != {}",
+            nb_coords,
+            y.len()
+        );
         let ret_val = unsafe {
             gdal_sys::OCTTransform(
                 self.inner,
@@ -45,7 +57,13 @@ impl CoordTransform {
                 if z.is_empty() {
                     null_mut()
                 } else {
-                    assert_eq!(nb_coords, z.len());
+                    assert_eq!(
+                        nb_coords,
+                        z.len(),
+                        "transform coordinate slices have different length: {} != {}",
+                        nb_coords,
+                        z.len()
+                    );
                     z.as_mut_ptr()
                 },
             ) == 1

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -80,11 +80,13 @@ fn transform_coordinates() {
     let transform = CoordTransform::new(&spatial_ref1, &spatial_ref2).unwrap();
     let mut xs = [23.43, 23.50];
     let mut ys = [37.58, 37.70];
+    let mut zs = [32.0, 20.0];
     transform
-        .transform_coords(&mut xs, &mut ys, &mut [])
+        .transform_coords(&mut xs, &mut ys, &mut zs)
         .unwrap();
     assert_almost_eq(xs[0], 5509543.1508097);
     assert_almost_eq(ys[0], 1716062.1916192223);
+    assert_almost_eq(zs[0], 32.0);
 }
 
 #[test]
@@ -169,10 +171,9 @@ fn failing_transformation() {
 
     let mut x = [1000000.0];
     let mut y = [1000000.0];
-    let mut z = [0.0];
 
     let trafo = CoordTransform::new(&wgs84, &webmercator).unwrap();
-    let r = trafo.transform_coords(&mut x, &mut y, &mut z);
+    let r = trafo.transform_coords(&mut x, &mut y, &mut []);
 
     assert!(r.is_err());
     if let GdalError::InvalidCoordinateRange { .. } = r.unwrap_err() {

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -169,7 +169,7 @@ fn failing_transformation() {
 
     let mut x = [1000000.0];
     let mut y = [1000000.0];
-    let mut z = [0.0, 0.0];
+    let mut z = [0.0];
 
     let trafo = CoordTransform::new(&wgs84, &webmercator).unwrap();
     let r = trafo.transform_coords(&mut x, &mut y, &mut z);

--- a/src/spatial_ref/tests.rs
+++ b/src/spatial_ref/tests.rs
@@ -81,7 +81,7 @@ fn transform_coordinates() {
     let mut xs = [23.43, 23.50];
     let mut ys = [37.58, 37.70];
     transform
-        .transform_coords(&mut xs, &mut ys, &mut [0.0, 0.0])
+        .transform_coords(&mut xs, &mut ys, &mut [])
         .unwrap();
     assert_almost_eq(xs[0], 5509543.1508097);
     assert_almost_eq(ys[0], 1716062.1916192223);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Currently `CoordTransform::transform` accepts three `&mut [f64]` slices (for x, y, and z coordinates).  This prevents us from using it for 2D transform (whereas in the C api, we would have passed null ptr for z).  This PR supports that by checking if the z slice is empty, and passes null_ptr instead.

Also, currently we only check if the x and y slices have the same length.  This causes sigsegv when passing incorrect z slice.  We've also added a assertion for that.

Modified one of the existing tests that didn't use the z coordinate to instead pass an empty slice.