### PR TITLE
Filenames now must allow references to `Path`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - Added `rename` and `delete` to `gdal::Driver`
   - <https://github.com/georust/gdal/pull/226>
 
+- **Breaking**: File paths must now implement `AsRef<Path>`
+  - <https://github.com/georust/gdal/pull/230>
+
 ## 0.8 - 0.10
 
 - Update types to fix build on ppc64le.

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -168,7 +168,7 @@ impl Dataset {
 
     /// Open a dataset at the given `path` with default
     /// options.
-    pub fn open(path: &Path) -> Result<Dataset> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Dataset> {
         Self::open_ex(path, DatasetOptions::default())
     }
 
@@ -176,7 +176,7 @@ impl Dataset {
     /// [`GDALOpenEx`].
     ///
     /// [`GDALOpenEx`]: https://gdal.org/doxygen/gdal_8h.html#a9cb8585d0b3c16726b08e25bcc94274a
-    pub fn open_ex(path: &Path, options: DatasetOptions) -> Result<Dataset> {
+    pub fn open_ex<P: AsRef<Path>>(path: P, options: DatasetOptions) -> Result<Dataset> {
         crate::driver::_register_drivers();
 
         let c_filename = _path_to_c_string(path)?;
@@ -303,13 +303,13 @@ impl Dataset {
         Ok(())
     }
 
-    pub fn create_copy(
+    pub fn create_copy<P: AsRef<Path>>(
         &self,
         driver: &Driver,
-        filename: &str,
+        filename: P,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
-        let c_filename = CString::new(filename)?;
+        let c_filename = _path_to_c_string(filename)?;
 
         let mut c_options = CslStringList::new();
         for option in options {

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -169,7 +169,7 @@ impl Dataset {
     /// Open a dataset at the given `path` with default
     /// options.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Dataset> {
-        Self::open_ex(path, DatasetOptions::default())
+        Self::_open_ex(path.as_ref(), DatasetOptions::default())
     }
 
     /// Open a dataset with extended options. See
@@ -177,6 +177,10 @@ impl Dataset {
     ///
     /// [`GDALOpenEx`]: https://gdal.org/doxygen/gdal_8h.html#a9cb8585d0b3c16726b08e25bcc94274a
     pub fn open_ex<P: AsRef<Path>>(path: P, options: DatasetOptions) -> Result<Dataset> {
+        Self::_open_ex(path.as_ref(), options)
+    }
+
+    fn _open_ex(path: &Path, options: DatasetOptions) -> Result<Dataset> {
         crate::driver::_register_drivers();
 
         let c_filename = _path_to_c_string(path)?;
@@ -307,6 +311,15 @@ impl Dataset {
         &self,
         driver: &Driver,
         filename: P,
+        options: &[RasterCreationOption],
+    ) -> Result<Dataset> {
+        Self::_create_copy(&self, driver, filename.as_ref(), options)
+    }
+
+    fn _create_copy(
+        &self,
+        driver: &Driver,
+        filename: &Path,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
         let c_filename = _path_to_c_string(filename)?;

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -313,7 +313,7 @@ impl Dataset {
         filename: P,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
-        Self::_create_copy(&self, driver, filename.as_ref(), options)
+        Self::_create_copy(self, driver, filename.as_ref(), options)
     }
 
     fn _create_copy(

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -96,7 +96,7 @@ impl Driver {
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
         Self::_create_with_band_type_with_options::<T>(
-            &self,
+            self,
             filename.as_ref(),
             size_x,
             size_y,
@@ -149,7 +149,7 @@ impl Driver {
     /// Calls `GDALDeleteDataset()`
     ///
     pub fn delete<P: AsRef<Path>>(&self, filename: P) -> Result<()> {
-        Self::_delete(&self, filename.as_ref())
+        Self::_delete(self, filename.as_ref())
     }
 
     fn _delete(&self, filename: &Path) -> Result<()> {
@@ -175,7 +175,7 @@ impl Driver {
         new_filename: P1,
         old_filename: P2,
     ) -> Result<()> {
-        Self::_rename(&self, new_filename.as_ref(), old_filename.as_ref())
+        Self::_rename(self, new_filename.as_ref(), old_filename.as_ref())
     }
 
     fn _rename(&self, new_filename: &Path, old_filename: &Path) -> Result<()> {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -95,6 +95,24 @@ impl Driver {
         bands: isize,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
+        Self::_create_with_band_type_with_options::<T>(
+            &self,
+            filename.as_ref(),
+            size_x,
+            size_y,
+            bands,
+            options,
+        )
+    }
+
+    fn _create_with_band_type_with_options<T: GdalType>(
+        &self,
+        filename: &Path,
+        size_x: isize,
+        size_y: isize,
+        bands: isize,
+        options: &[RasterCreationOption],
+    ) -> Result<Dataset> {
         let mut options_c = CslStringList::new();
         for option in options {
             options_c.set_name_value(option.key, option.value)?;
@@ -131,6 +149,10 @@ impl Driver {
     /// Calls `GDALDeleteDataset()`
     ///
     pub fn delete<P: AsRef<Path>>(&self, filename: P) -> Result<()> {
+        Self::_delete(&self, filename.as_ref())
+    }
+
+    fn _delete(&self, filename: &Path) -> Result<()> {
         let c_filename = _path_to_c_string(filename)?;
 
         let rv = unsafe { gdal_sys::GDALDeleteDataset(self.c_driver, c_filename.as_ptr()) };
@@ -153,6 +175,10 @@ impl Driver {
         new_filename: P1,
         old_filename: P2,
     ) -> Result<()> {
+        Self::_rename(&self, new_filename.as_ref(), old_filename.as_ref())
+    }
+
+    fn _rename(&self, new_filename: &Path, old_filename: &Path) -> Result<()> {
         let c_old_filename = _path_to_c_string(old_filename)?;
         let c_new_filename = _path_to_c_string(new_filename)?;
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -66,30 +66,30 @@ impl Driver {
         _string(rv)
     }
 
-    pub fn create(
+    pub fn create<P: AsRef<Path>>(
         &self,
-        filename: &str,
+        filename: P,
         size_x: isize,
         size_y: isize,
         bands: isize,
     ) -> Result<Dataset> {
-        self.create_with_band_type::<u8>(filename, size_x, size_y, bands)
+        self.create_with_band_type::<u8, _>(filename, size_x, size_y, bands)
     }
 
-    pub fn create_with_band_type<T: GdalType>(
+    pub fn create_with_band_type<T: GdalType, P: AsRef<Path>>(
         &self,
-        filename: &str,
+        filename: P,
         size_x: isize,
         size_y: isize,
         bands: isize,
     ) -> Result<Dataset> {
         let options = [];
-        self.create_with_band_type_with_options::<T>(filename, size_x, size_y, bands, &options)
+        self.create_with_band_type_with_options::<T, _>(filename, size_x, size_y, bands, &options)
     }
 
-    pub fn create_with_band_type_with_options<T: GdalType>(
+    pub fn create_with_band_type_with_options<T: GdalType, P: AsRef<Path>>(
         &self,
-        filename: &str,
+        filename: P,
         size_x: isize,
         size_y: isize,
         bands: isize,
@@ -100,7 +100,7 @@ impl Driver {
             options_c.set_name_value(option.key, option.value)?;
         }
 
-        let c_filename = CString::new(filename)?;
+        let c_filename = _path_to_c_string(filename)?;
         let c_dataset = unsafe {
             gdal_sys::GDALCreate(
                 self.c_driver,
@@ -120,8 +120,8 @@ impl Driver {
         Ok(unsafe { Dataset::from_c_dataset(c_dataset) })
     }
 
-    pub fn create_vector_only(&self, filename: &str) -> Result<Dataset> {
-        self.create_with_band_type::<u8>(filename, 0, 0, 0)
+    pub fn create_vector_only<P: AsRef<Path>>(&self, filename: P) -> Result<Dataset> {
+        self.create_with_band_type::<u8, _>(filename, 0, 0, 0)
     }
 
     /// Delete named dataset.
@@ -130,7 +130,7 @@ impl Driver {
     ///
     /// Calls `GDALDeleteDataset()`
     ///
-    pub fn delete(&self, filename: &Path) -> Result<()> {
+    pub fn delete<P: AsRef<Path>>(&self, filename: P) -> Result<()> {
         let c_filename = _path_to_c_string(filename)?;
 
         let rv = unsafe { gdal_sys::GDALDeleteDataset(self.c_driver, c_filename.as_ptr()) };
@@ -148,7 +148,11 @@ impl Driver {
     ///
     /// Calls `GDALRenameDataset()`
     ///
-    pub fn rename(&self, new_filename: &Path, old_filename: &Path) -> Result<()> {
+    pub fn rename<P1: AsRef<Path>, P2: AsRef<Path>>(
+        &self,
+        new_filename: P1,
+        old_filename: P2,
+    ) -> Result<()> {
         let c_old_filename = _path_to_c_string(old_filename)?;
         let c_new_filename = _path_to_c_string(new_filename)?;
 

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -155,9 +155,7 @@ fn test_rename_remove_raster() {
 
     let driver = Driver::get("GTiff").unwrap();
 
-    dataset
-        .create_copy(&driver, &mem_file_path_a.to_string_lossy(), &[])
-        .unwrap();
+    dataset.create_copy(&driver, &mem_file_path_a, &[]).unwrap();
 
     driver.rename(mem_file_path_b, mem_file_path_a).unwrap();
 
@@ -270,7 +268,9 @@ fn test_create() {
 #[test]
 fn test_create_with_band_type() {
     let driver = Driver::get("MEM").unwrap();
-    let dataset = driver.create_with_band_type::<f32>("", 10, 20, 3).unwrap();
+    let dataset = driver
+        .create_with_band_type::<f32, _>("", 10, 20, 3)
+        .unwrap();
     assert_eq!(dataset.raster_size(), (10, 20));
     assert_eq!(dataset.raster_count(), 3);
     assert_eq!(dataset.driver().short_name(), "MEM");
@@ -307,7 +307,7 @@ fn test_create_with_band_type_with_options() {
     let tmp_filename = "/tmp/test.tif";
     {
         let dataset = driver
-            .create_with_band_type_with_options::<u8>(tmp_filename, 256, 256, 1, &options)
+            .create_with_band_type_with_options::<u8, _>(tmp_filename, 256, 256, 1, &options)
             .unwrap();
         let rasterband = dataset.rasterband(1).unwrap();
         let block_size = rasterband.block_size();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,8 @@ pub fn _last_null_pointer_err(method_name: &'static str) -> GdalError {
     }
 }
 
-pub fn _path_to_c_string(path: &Path) -> Result<CString> {
-    let path_str = path.to_string_lossy();
+pub fn _path_to_c_string<P: AsRef<Path>>(path: P) -> Result<CString> {
+    let path_ref: &Path = path.as_ref();
+    let path_str = path_ref.to_string_lossy();
     CString::new(path_str.as_ref()).map_err(Into::into)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,8 +52,7 @@ pub fn _last_null_pointer_err(method_name: &'static str) -> GdalError {
     }
 }
 
-pub fn _path_to_c_string<P: AsRef<Path>>(path: P) -> Result<CString> {
-    let path_ref: &Path = path.as_ref();
-    let path_str = path_ref.to_string_lossy();
+pub fn _path_to_c_string(path: &Path) -> Result<CString> {
+    let path_str = path.to_string_lossy();
     CString::new(path_str.as_ref()).map_err(Into::into)
 }

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -631,7 +631,7 @@ mod tests {
         {
             let driver = Driver::get("GeoJSON").unwrap();
             let mut ds = driver
-                .create_vector_only(&fixture!("output.geojson").to_string_lossy())
+                .create_vector_only(&fixture!("output.geojson"))
                 .unwrap();
             let mut layer = ds.create_layer(Default::default()).unwrap();
             layer

--- a/src/vsi.rs
+++ b/src/vsi.rs
@@ -74,7 +74,7 @@ pub fn create_mem_file_from_ref<P: AsRef<Path>>(
 }
 
 fn _create_mem_file_from_ref<'d>(file_name: &Path, data: &'d mut [u8]) -> Result<MemFileRef<'d>> {
-    let file_name_c = _path_to_c_string(&file_name)?;
+    let file_name_c = _path_to_c_string(file_name)?;
 
     let handle = unsafe {
         VSIFileFromMemBuffer(
@@ -102,7 +102,7 @@ pub fn unlink_mem_file<P: AsRef<Path>>(file_name: P) -> Result<()> {
 }
 
 fn _unlink_mem_file(file_name: &Path) -> Result<()> {
-    let file_name_c = _path_to_c_string(&file_name)?;
+    let file_name_c = _path_to_c_string(file_name)?;
 
     let rv = unsafe { VSIUnlink(file_name_c.as_ptr()) };
 


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

According to affirmation in https://github.com/georust/gdal/issues/227 I changed all file paths to be implementing `AsRef<Path>`.
This is based on @lnicola's idea and is similar to https://doc.rust-lang.org/std/fs/struct.File.html#method.open.

This introduced generics on the methods but I guess less code-breaking since you can still input `&str`s.