### PR TITLE
adapt try build expected error to new output

### DIFF
--- a/tests/compile-tests/01-features-aliasing-errors.stderr
+++ b/tests/compile-tests/01-features-aliasing-errors.stderr
@@ -7,4 +7,4 @@ error[E0502]: cannot borrow `layer` as immutable because it is also borrowed as 
   |              mutable borrow occurs here
   |              mutable borrow later used here
 9 |         let _ = layer.defn();
-  |                 ^^^^^ immutable borrow occurs here
+  |                 ^^^^^^^^^^^^ immutable borrow occurs here


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
it works with current stable beta and nightly on linux
