### PR TITLE
owned layers from a dataset

### DIFF
--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -1,3 +1,5 @@
+use gdal::vector::LayerAccess;
+
 fn run() -> gdal::errors::Result<()> {
     use chrono::Duration;
     use gdal::vector::{Defn, Feature, FieldDefn, FieldValue};

--- a/examples/write_ogr.rs
+++ b/examples/write_ogr.rs
@@ -1,5 +1,5 @@
 use gdal::errors::Result;
-use gdal::vector::{Defn, Feature, FieldDefn, FieldValue, Geometry, OGRFieldType};
+use gdal::vector::{Defn, Feature, FieldDefn, FieldValue, Geometry, LayerAccess, OGRFieldType};
 use gdal::Driver;
 use std::fs;
 

--- a/src/vector/defn.rs
+++ b/src/vector/defn.rs
@@ -1,6 +1,6 @@
 use crate::spatial_ref::SpatialRef;
 use crate::utils::{_last_null_pointer_err, _string};
-use crate::vector::layer::Layer;
+use crate::vector::LayerAccess;
 use gdal_sys::{
     self, OGRFeatureDefnH, OGRFieldDefnH, OGRFieldType, OGRGeomFieldDefnH, OGRwkbGeometryType,
 };
@@ -55,7 +55,7 @@ impl Defn {
         }
     }
 
-    pub fn from_layer(lyr: &Layer) -> Defn {
+    pub fn from_layer<L: LayerAccess>(lyr: &L) -> Defn {
         let c_defn = unsafe { gdal_sys::OGR_L_GetLayerDefn(lyr.c_layer()) };
         Defn { c_defn }
     }

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -1,7 +1,6 @@
 use crate::utils::{_last_null_pointer_err, _string, _string_array};
 use crate::vector::geometry::Geometry;
-use crate::vector::layer::Layer;
-use crate::vector::Defn;
+use crate::vector::{Defn, LayerAccess};
 use gdal_sys::{self, OGRErr, OGRFeatureH, OGRFieldType};
 use libc::c_longlong;
 use libc::{c_double, c_int};
@@ -487,7 +486,7 @@ impl<'a> Feature<'a> {
         Ok(&self.geometry[idx])
     }
 
-    pub fn create(&self, lyr: &Layer) -> Result<()> {
+    pub fn create<L: LayerAccess>(&self, lyr: &L) -> Result<()> {
         let rv = unsafe { gdal_sys::OGR_L_CreateFeature(lyr.c_layer(), self.c_feature) };
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -108,28 +108,103 @@ impl<'a> MajorObject for Layer<'a> {
 
 impl<'a> Metadata for Layer<'a> {}
 
+impl<'a> LayerAccess for Layer<'a> {
+    unsafe fn c_layer(&self) -> OGRLayerH {
+        self.c_layer
+    }
+
+    fn defn(&self) -> &Defn {
+        &self.defn
+    }
+}
+
 impl<'a> Layer<'a> {
     /// Creates a new Layer from a GDAL layer pointer
     ///
     /// # Safety
     /// This method operates on a raw C pointer
-    pub unsafe fn from_c_layer(_: &'a Dataset, c_layer: OGRLayerH) -> Layer<'a> {
+    pub(crate) unsafe fn from_c_layer(_: &'a Dataset, c_layer: OGRLayerH) -> Self {
         let c_defn = gdal_sys::OGR_L_GetLayerDefn(c_layer);
         let defn = Defn::from_c_defn(c_defn);
-        Layer {
+        Self {
             c_layer,
             defn,
             phantom: PhantomData,
         }
     }
+}
 
+/// Layer in a vector dataset
+///
+/// ```
+/// use std::path::Path;
+/// use gdal::Dataset;
+///
+/// let dataset = Dataset::open(Path::new("fixtures/roads.geojson")).unwrap();
+/// let mut layer = dataset.into_layer(0).unwrap();
+/// for feature in layer.features() {
+///     // do something with each feature
+/// }
+/// ```
+#[derive(Debug)]
+pub struct OwnedLayer {
+    c_layer: OGRLayerH,
+    defn: Defn,
+    // we store the dataset to prevent dropping (i.e. closing) it
+    _dataset: Dataset,
+}
+
+impl MajorObject for OwnedLayer {
+    unsafe fn gdal_object_ptr(&self) -> GDALMajorObjectH {
+        self.c_layer
+    }
+}
+
+impl Metadata for OwnedLayer {}
+
+impl LayerAccess for OwnedLayer {
+    unsafe fn c_layer(&self) -> OGRLayerH {
+        self.c_layer
+    }
+
+    fn defn(&self) -> &Defn {
+        &self.defn
+    }
+}
+
+impl OwnedLayer {
+    /// Creates a new Layer from a GDAL layer pointer
+    ///
+    /// # Safety
+    /// This method operates on a raw C pointer
+    pub(crate) unsafe fn from_c_layer(dataset: Dataset, c_layer: OGRLayerH) -> Self {
+        let c_defn = gdal_sys::OGR_L_GetLayerDefn(c_layer);
+        let defn = Defn::from_c_defn(c_defn);
+        Self {
+            c_layer,
+            defn,
+            _dataset: dataset,
+        }
+    }
+
+    /// Returns the `Dataset` this layer belongs to and consumes this layer.
+    pub fn into_dataset(self) -> Dataset {
+        self._dataset
+    }
+}
+
+/// As long we have a 1:1 mapping between a dataset and a layer, it is `Send`.
+/// We cannot allow a layer to be send, when two or more access (and modify) the same `Dataset`.
+unsafe impl Send for OwnedLayer {}
+
+pub trait LayerAccess: Sized {
     /// Returns the C wrapped pointer
     ///
     /// # Safety
     /// This method returns a raw C pointer
-    pub unsafe fn c_layer(&self) -> OGRLayerH {
-        self.c_layer
-    }
+    unsafe fn c_layer(&self) -> OGRLayerH;
+
+    fn defn(&self) -> &Defn;
 
     /// Returns the feature with the given feature id `fid`, or `None` if not found.
     ///
@@ -138,8 +213,8 @@ impl<'a> Layer<'a> {
     /// Not all drivers support this efficiently; however, the call should always work if the
     /// feature exists, as a fallback implementation just scans all the features in the layer
     /// looking for the desired feature.
-    pub fn feature(&self, fid: u64) -> Option<Feature> {
-        let c_feature = unsafe { gdal_sys::OGR_L_GetFeature(self.c_layer, fid as i64) };
+    fn feature(&self, fid: u64) -> Option<Feature> {
+        let c_feature = unsafe { gdal_sys::OGR_L_GetFeature(self.c_layer(), fid as i64) };
         if c_feature.is_null() {
             None
         } else {
@@ -152,7 +227,7 @@ impl<'a> Layer<'a> {
     /// **Note.** This method resets the current index to
     /// the beginning before iteration. It also borrows the
     /// layer mutably, preventing any overlapping borrows.
-    pub fn features(&mut self) -> FeatureIterator {
+    fn features(&mut self) -> FeatureIterator {
         self.reset_feature_reading();
         FeatureIterator::_with_layer(self)
     }
@@ -160,45 +235,41 @@ impl<'a> Layer<'a> {
     /// Set a spatial filter on this layer.
     ///
     /// Refer [OGR_L_SetSpatialFilter](https://gdal.org/doxygen/classOGRLayer.html#a75c06b4993f8eb76b569f37365cd19ab)
-    pub fn set_spatial_filter(&mut self, geometry: &Geometry) {
-        unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer, geometry.c_geometry()) };
+    fn set_spatial_filter(&mut self, geometry: &Geometry) {
+        unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer(), geometry.c_geometry()) };
     }
 
     /// Set a spatial rectangle filter on this layer by specifying the bounds of a rectangle.
-    pub fn set_spatial_filter_rect(&mut self, min_x: f64, min_y: f64, max_x: f64, max_y: f64) {
-        unsafe { gdal_sys::OGR_L_SetSpatialFilterRect(self.c_layer, min_x, min_y, max_x, max_y) };
+    fn set_spatial_filter_rect(&mut self, min_x: f64, min_y: f64, max_x: f64, max_y: f64) {
+        unsafe { gdal_sys::OGR_L_SetSpatialFilterRect(self.c_layer(), min_x, min_y, max_x, max_y) };
     }
 
     /// Clear spatial filters set on this layer.
-    pub fn clear_spatial_filter(&mut self) {
-        unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer, null_mut()) };
+    fn clear_spatial_filter(&mut self) {
+        unsafe { gdal_sys::OGR_L_SetSpatialFilter(self.c_layer(), null_mut()) };
     }
 
     /// Get the name of this layer.
-    pub fn name(&self) -> String {
-        let rv = unsafe { gdal_sys::OGR_L_GetName(self.c_layer) };
+    fn name(&self) -> String {
+        let rv = unsafe { gdal_sys::OGR_L_GetName(self.c_layer()) };
         _string(rv)
     }
 
-    pub fn has_capability(&self, capability: LayerCaps) -> bool {
+    fn has_capability(&self, capability: LayerCaps) -> bool {
         unsafe {
-            gdal_sys::OGR_L_TestCapability(self.c_layer, capability.into_cstring().as_ptr()) == 1
+            gdal_sys::OGR_L_TestCapability(self.c_layer(), capability.into_cstring().as_ptr()) == 1
         }
     }
 
-    pub fn defn(&self) -> &Defn {
-        &self.defn
-    }
-
-    pub fn create_defn_fields(&self, fields_def: &[(&str, OGRFieldType::Type)]) -> Result<()> {
+    fn create_defn_fields(&self, fields_def: &[(&str, OGRFieldType::Type)]) -> Result<()> {
         for fd in fields_def {
             let fdefn = FieldDefn::new(fd.0, fd.1)?;
             fdefn.add_to_layer(self)?;
         }
         Ok(())
     }
-    pub fn create_feature(&mut self, geometry: Geometry) -> Result<()> {
-        let feature = Feature::new(&self.defn)?;
+    fn create_feature(&mut self, geometry: Geometry) -> Result<()> {
+        let feature = Feature::new(self.defn())?;
 
         let c_geometry = unsafe { geometry.into_c_geometry() };
         let rv = unsafe { gdal_sys::OGR_F_SetGeometryDirectly(feature.c_feature(), c_geometry) };
@@ -208,7 +279,7 @@ impl<'a> Layer<'a> {
                 method_name: "OGR_F_SetGeometryDirectly",
             });
         }
-        let rv = unsafe { gdal_sys::OGR_L_CreateFeature(self.c_layer, feature.c_feature()) };
+        let rv = unsafe { gdal_sys::OGR_L_CreateFeature(self.c_layer(), feature.c_feature()) };
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {
                 err: rv,
@@ -218,13 +289,13 @@ impl<'a> Layer<'a> {
         Ok(())
     }
 
-    pub fn create_feature_fields(
+    fn create_feature_fields(
         &mut self,
         geometry: Geometry,
         field_names: &[&str],
         values: &[FieldValue],
     ) -> Result<()> {
-        let mut ft = Feature::new(&self.defn)?;
+        let mut ft = Feature::new(self.defn())?;
         ft.set_geometry(geometry)?;
         for (fd, val) in field_names.iter().zip(values.iter()) {
             ft.set_field(fd, val)?;
@@ -239,8 +310,8 @@ impl<'a> Layer<'a> {
     ///
     /// The returned count takes the [spatial filter](`Layer::set_spatial_filter`) into account.
     /// For dynamic databases the count may not be exact.
-    pub fn feature_count(&self) -> u64 {
-        (unsafe { gdal_sys::OGR_L_GetFeatureCount(self.c_layer, 1) }) as u64
+    fn feature_count(&self) -> u64 {
+        (unsafe { gdal_sys::OGR_L_GetFeatureCount(self.c_layer(), 1) }) as u64
     }
 
     /// Returns the number of features in this layer, if it is possible to compute this
@@ -251,8 +322,8 @@ impl<'a> Layer<'a> {
     ///
     /// The returned count takes the [spatial filter](`Layer::set_spatial_filter`) into account.
     /// For dynamic databases the count may not be exact.
-    pub fn try_feature_count(&self) -> Option<u64> {
-        let rv = unsafe { gdal_sys::OGR_L_GetFeatureCount(self.c_layer, 0) };
+    fn try_feature_count(&self) -> Option<u64> {
+        let rv = unsafe { gdal_sys::OGR_L_GetFeatureCount(self.c_layer(), 0) };
         if rv < 0 {
             None
         } else {
@@ -271,7 +342,7 @@ impl<'a> Layer<'a> {
     ///
     /// Layers without any geometry may return [`OGRErr::OGRERR_FAILURE`] to indicate that no
     /// meaningful extents could be collected.
-    pub fn get_extent(&self) -> Result<gdal_sys::OGREnvelope> {
+    fn get_extent(&self) -> Result<gdal_sys::OGREnvelope> {
         let mut envelope = OGREnvelope {
             MinX: 0.0,
             MaxX: 0.0,
@@ -279,7 +350,7 @@ impl<'a> Layer<'a> {
             MaxY: 0.0,
         };
         let force = 1;
-        let rv = unsafe { gdal_sys::OGR_L_GetExtent(self.c_layer, &mut envelope, force) };
+        let rv = unsafe { gdal_sys::OGR_L_GetExtent(self.c_layer(), &mut envelope, force) };
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {
                 err: rv,
@@ -298,7 +369,7 @@ impl<'a> Layer<'a> {
     /// Depending on the driver, the returned extent may or may not take the [spatial
     /// filter](`Layer::set_spatial_filter`) into account. So it is safer to call `try_get_extent`
     /// without setting a spatial filter.
-    pub fn try_get_extent(&self) -> Result<Option<gdal_sys::OGREnvelope>> {
+    fn try_get_extent(&self) -> Result<Option<gdal_sys::OGREnvelope>> {
         let mut envelope = OGREnvelope {
             MinX: 0.0,
             MaxX: 0.0,
@@ -306,7 +377,7 @@ impl<'a> Layer<'a> {
             MaxY: 0.0,
         };
         let force = 0;
-        let rv = unsafe { gdal_sys::OGR_L_GetExtent(self.c_layer, &mut envelope, force) };
+        let rv = unsafe { gdal_sys::OGR_L_GetExtent(self.c_layer(), &mut envelope, force) };
         if rv == OGRErr::OGRERR_FAILURE {
             Ok(None)
         } else {
@@ -323,8 +394,8 @@ impl<'a> Layer<'a> {
     /// Fetch the spatial reference system for this layer.
     ///
     /// Refer [OGR_L_GetSpatialRef](https://gdal.org/doxygen/classOGRLayer.html#a75c06b4993f8eb76b569f37365cd19ab)
-    pub fn spatial_ref(&self) -> Result<SpatialRef> {
-        let c_obj = unsafe { gdal_sys::OGR_L_GetSpatialRef(self.c_layer) };
+    fn spatial_ref(&self) -> Result<SpatialRef> {
+        let c_obj = unsafe { gdal_sys::OGR_L_GetSpatialRef(self.c_layer()) };
         if c_obj.is_null() {
             return Err(_last_null_pointer_err("OGR_L_GetSpatialRef"));
         }
@@ -333,7 +404,7 @@ impl<'a> Layer<'a> {
 
     fn reset_feature_reading(&mut self) {
         unsafe {
-            gdal_sys::OGR_L_ResetReading(self.c_layer);
+            gdal_sys::OGR_L_ResetReading(self.c_layer());
         }
     }
 
@@ -344,9 +415,9 @@ impl<'a> Layer<'a> {
     /// Parameters:
     /// - `query` in restricted SQL WHERE format
     ///
-    pub fn set_attribute_filter(&mut self, query: &str) -> Result<()> {
+    fn set_attribute_filter(&mut self, query: &str) -> Result<()> {
         let c_str = CString::new(query)?;
-        let rv = unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, c_str.as_ptr()) };
+        let rv = unsafe { gdal_sys::OGR_L_SetAttributeFilter(self.c_layer(), c_str.as_ptr()) };
 
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {
@@ -362,9 +433,9 @@ impl<'a> Layer<'a> {
     ///
     /// From the GDAL docs: Note that installing a query string will generally result in resetting the current reading position
     ///
-    pub fn clear_attribute_filter(&mut self) {
+    fn clear_attribute_filter(&mut self) {
         unsafe {
-            gdal_sys::OGR_L_SetAttributeFilter(self.c_layer, null_mut());
+            gdal_sys::OGR_L_SetAttributeFilter(self.c_layer(), null_mut());
         }
     }
 }
@@ -397,14 +468,14 @@ impl<'a> Iterator for FeatureIterator<'a> {
 }
 
 impl<'a> FeatureIterator<'a> {
-    pub fn _with_layer(layer: &'a Layer) -> FeatureIterator<'a> {
+    pub fn _with_layer<L: LayerAccess>(layer: &'a L) -> FeatureIterator<'a> {
         let defn = layer.defn();
         let size_hint = layer
             .try_feature_count()
             .map(|s| s.try_into().ok())
             .flatten();
         FeatureIterator {
-            c_layer: layer.c_layer,
+            c_layer: unsafe { layer.c_layer() },
             size_hint,
             defn,
         }
@@ -442,7 +513,7 @@ impl FieldDefn {
     pub fn set_precision(&self, precision: i32) {
         unsafe { gdal_sys::OGR_Fld_SetPrecision(self.c_obj, precision as c_int) };
     }
-    pub fn add_to_layer(&self, layer: &Layer) -> Result<()> {
+    pub fn add_to_layer<L: LayerAccess>(&self, layer: &L) -> Result<()> {
         let rv = unsafe { gdal_sys::OGR_L_CreateField(layer.c_layer(), self.c_obj, 1) };
         if rv != OGRErr::OGRERR_NONE {
             return Err(GdalError::OgrError {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -28,7 +28,7 @@ pub use defn::{Defn, Field, FieldIterator};
 pub use feature::{Feature, FieldValue, FieldValueIterator};
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
 pub use geometry::Geometry;
-pub use layer::{FeatureIterator, FieldDefn, Layer, LayerCaps};
+pub use layer::{FeatureIterator, FieldDefn, Layer, LayerAccess, LayerCaps, OwnedLayer};
 pub use ops::GeometryIntersection;
 
 use crate::errors::Result;

--- a/src/vector/sql.rs
+++ b/src/vector/sql.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use gdal_sys::GDALDatasetH;
 
-use crate::vector::Layer;
+use crate::vector::{Layer, LayerAccess};
 
 /// The result of a SQL query executed by
 /// [`Dataset::execute_sql()`](crate::Dataset::execute_sql()). It is just a thin wrapper around a

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    Feature, FeatureIterator, FieldValue, Geometry, Layer, LayerCaps::*, OGRFieldType,
+    Feature, FeatureIterator, FieldValue, Geometry, Layer, LayerAccess, LayerCaps::*, OGRFieldType,
     OGRwkbGeometryType,
 };
 use crate::spatial_ref::SpatialRef;
@@ -159,6 +159,25 @@ mod tests {
         let layers = ds.layers();
         assert_eq!(layers.size_hint(), (3, Some(3)));
         assert_eq!(layers.count(), 3);
+    }
+
+    #[test]
+    fn test_owned_layers() {
+        let ds = Dataset::open(fixture!("three_layer_ds.s3db")).unwrap();
+
+        assert_eq!(ds.layer_count(), 3);
+
+        let mut layer = ds.into_layer(0).unwrap();
+
+        {
+            let feature = layer.features().next().unwrap();
+            assert_eq!(feature.field("id").unwrap(), None);
+        }
+
+        // convert back to dataset
+
+        let ds = layer.into_dataset();
+        assert_eq!(ds.layer_count(), 3);
     }
 
     #[test]

--- a/src/vector/vector_tests/sql.rs
+++ b/src/vector/vector_tests/sql.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::{
     fixture,
-    vector::{sql, Geometry},
+    vector::{sql, Geometry, LayerAccess},
     Dataset,
 };
 

--- a/tests/compile-tests/01-features-aliasing-errors.rs
+++ b/tests/compile-tests/01-features-aliasing-errors.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use gdal::vector::LayerAccess;
 use gdal::Dataset;
 
 fn main() {

--- a/tests/compile-tests/01-features-aliasing-errors.stderr
+++ b/tests/compile-tests/01-features-aliasing-errors.stderr
@@ -1,10 +1,10 @@
 error[E0502]: cannot borrow `layer` as immutable because it is also borrowed as mutable
- --> $DIR/01-features-aliasing-errors.rs:9:17
-  |
-8 |     for _ in layer.features() {
-  |              ----------------
-  |              |
-  |              mutable borrow occurs here
-  |              mutable borrow later used here
-9 |         let _ = layer.defn();
-  |                 ^^^^^^^^^^^^ immutable borrow occurs here
+  --> $DIR/01-features-aliasing-errors.rs:10:17
+   |
+9  |     for _ in layer.features() {
+   |              ----------------
+   |              |
+   |              mutable borrow occurs here
+   |              mutable borrow later used here
+10 |         let _ = layer.defn();
+   |                 ^^^^^ immutable borrow occurs here


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

We ran into the problem of having non-`Send` `Layer`s. Without `Send` it is barely usable in an asynchronous or threading context. You cannot store it somewhere and create tasks that do something with them since you would need to send a `Layer` to another thread.

From previous discussions about thread-safety in GDAL we found out that we must not access `Dataset`s or `Layer`s at the same time from different threads. But for `Dataset`s, we found that it is safe to `Send` them to another thread since GDAL 2.4 (or something). For `Layer`s, it is actually okay to assume that the are `Send` as long as we have a one-to-one relationship between `Dataset`s or `Layer`s, or, stated differently, we must ensure that there are no two `Layer`s that point to one `Dataset`. If we would have to `Layer`s pointing to the same `Dataset` and they are `Send`, then we could have two different threads accessing the same `Dataset`. We must not allow this.

However, from discussions with @jdroenner , we thought that if we would introduce a `Layer` that owns its `Dataset`, we could make it `Send` since we can ensure that the `Dataset` isn't accessed another time, for instance, from another thread.

So in this draft PR I've created an `OwnedLayer` that does exactly this, it encapsulates a `Layer` and its `Dataset`. In `Dataset`, we can then choose if we want to have a reference to `Layer` or we want to convert our `Dataset` into an `OwnedLayer`. I've added a test that this behavior works.

Since the operations on `Layer` and `OwnedLayer` are more or less the same, I've transferred them into a `LayerAccess` trait. This unfortunately would mean a breaking change. On the other hand, it means not much more code for preserving both types.

Having said all this, what are your opinions on `OwnedLayer`s?
Do you like or criticize the concept?
What are your thoughts on naming the two types?
