### PR TITLE
Fix clippy and fmt errors

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -846,7 +846,7 @@ impl<'a> Iterator for LayerIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match Some(self.count).map(|s| s.try_into().ok()).flatten() {
+        match Some(self.count).and_then(|s| s.try_into().ok()) {
             Some(size) => (size, Some(size)),
             None => (0, None),
         }

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -676,7 +676,7 @@ impl<'a> Iterator for FieldValueIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match Some(self.count).map(|s| s.try_into().ok()).flatten() {
+        match Some(self.count).and_then(|s| s.try_into().ok()) {
             Some(size) => (size, Some(size)),
             None => (0, None),
         }

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -488,8 +488,7 @@ impl<'a> Iterator for FeatureIterator<'a> {
 impl<'a> FeatureIterator<'a> {
     pub(crate) fn _with_layer<L: LayerAccess>(layer: &'a L) -> Self {
         let defn = layer.defn();
-        let size_hint = layer
-            .try_feature_count().and_then(|s| s.try_into().ok());
+        let size_hint = layer.try_feature_count().and_then(|s| s.try_into().ok());
         Self {
             c_layer: unsafe { layer.c_layer() },
             size_hint,
@@ -535,8 +534,7 @@ where
 
 impl OwnedFeatureIterator {
     pub(crate) fn _with_layer(layer: OwnedLayer) -> Self {
-        let size_hint = layer
-            .try_feature_count().and_then(|s| s.try_into().ok());
+        let size_hint = layer.try_feature_count().and_then(|s| s.try_into().ok());
         Self { layer, size_hint }
     }
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -489,9 +489,7 @@ impl<'a> FeatureIterator<'a> {
     pub(crate) fn _with_layer<L: LayerAccess>(layer: &'a L) -> Self {
         let defn = layer.defn();
         let size_hint = layer
-            .try_feature_count()
-            .map(|s| s.try_into().ok())
-            .flatten();
+            .try_feature_count().and_then(|s| s.try_into().ok());
         Self {
             c_layer: unsafe { layer.c_layer() },
             size_hint,
@@ -538,9 +536,7 @@ where
 impl OwnedFeatureIterator {
     pub(crate) fn _with_layer(layer: OwnedLayer) -> Self {
         let size_hint = layer
-            .try_feature_count()
-            .map(|s| s.try_into().ok())
-            .flatten();
+            .try_feature_count().and_then(|s| s.try_into().ok());
         Self { layer, size_hint }
     }
 

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -501,7 +501,7 @@ mod tests {
             assert_eq!(geom.geometry_type(), OGRwkbGeometryType::wkbLineString);
             assert!(feature.geometry_by_index(1).is_err());
             let geom = feature.geometry_by_name("");
-            assert!(!geom.is_err());
+            assert!(geom.is_ok());
             let geom = feature.geometry_by_name("").unwrap();
             assert_eq!(geom.geometry_type(), OGRwkbGeometryType::wkbLineString);
             assert!(feature.geometry_by_name("FOO").is_err());


### PR DESCRIPTION
- [xI agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

New Lints (https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten) and formatting errors have been recently introduced to rust, producing errors in the CI (See for example: https://github.com/georust/gdal/pull/260 ). 

This PR addresses this issues. 