### PR TITLE
Deprecate Transaction::dataset{,_mut} in favour of Deref{,Mut}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,10 @@
 
   - <https://github.com/georust/gdal/pull/278>
 
+- Deprecate `Transaction::dataset` and `Transaction::dataset_mut`. Add `Deref` and `DerefMut` implementations instead.
+
+  - <https://github.com/georust/gdal/pull/265>
+
 ## 0.12
 
 - Bump Rust edition to 2021


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

