### PR TITLE
Mark `SpatialRef::from_c_obj` as unsafe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Breaking**: Add `gdal::vector::OwnedLayer`, `gdal::vector::LayerAccess` and `gdal::vector::layer::OwnedFeatureIterator`. This requires importing `gdal::vector::LayerAccess` for using most vector layer methods.
+
+  - https://github.com/georust/gdal/pull/238
+
+- **Breaking**: `SpatialRef::from_c_obj` is now unsafe.
+
+  - https://github.com/georust/gdal/pull/267
+
 - Add `programs::raster::build_vrt`
 - Add `GeoTransformEx` extension trait with `apply` and `invert`
 
@@ -10,10 +18,6 @@
 - Add `gdal::vector::geometry_type_to_name`
 
   - <https://github.com/georust/gdal/pull/250>
-
-- **Breaking**: Add `gdal::vector::OwnedLayer`, `gdal::vector::LayerAccess` and `gdal::vector::layer::OwnedFeatureIterator`. This requires importing `gdal::vector::LayerAccess` for using most vector layer methods.
-
-  - https://github.com/georust/gdal/pull/238
 
 ## 0.12
 

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -214,8 +214,12 @@ impl SpatialRef {
         }
     }
 
-    pub fn from_c_obj(c_obj: OGRSpatialReferenceH) -> Result<SpatialRef> {
-        let mut_c_obj = unsafe { gdal_sys::OSRClone(c_obj) };
+    /// Returns a wrapped `SpatialRef` from a raw C API handle.
+    ///
+    /// # Safety
+    /// The handle passed to this function must be valid.
+    pub unsafe fn from_c_obj(c_obj: OGRSpatialReferenceH) -> Result<SpatialRef> {
+        let mut_c_obj = gdal_sys::OSRClone(c_obj);
         if mut_c_obj.is_null() {
             Err(_last_null_pointer_err("OSRClone"))
         } else {

--- a/src/vector/defn.rs
+++ b/src/vector/defn.rs
@@ -20,7 +20,7 @@ impl Defn {
     /// Creates a new Defn by wrapping a C pointer
     ///
     /// # Safety
-    /// This method operates on a raw C pointer    
+    /// This method operates on a raw C pointer
     pub unsafe fn from_c_defn(c_defn: OGRFeatureDefnH) -> Defn {
         Defn { c_defn }
     }
@@ -160,6 +160,6 @@ impl<'a> GeomField<'a> {
         if c_obj.is_null() {
             return Err(_last_null_pointer_err("OGR_GFld_GetSpatialRef"));
         }
-        SpatialRef::from_c_obj(c_obj)
+        unsafe { SpatialRef::from_c_obj(c_obj) }
     }
 }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -47,7 +47,7 @@ impl Geometry {
     /// Set the wrapped C pointer
     ///
     /// # Safety
-    /// This method operates on a raw C pointer    
+    /// This method operates on a raw C pointer
     pub unsafe fn set_c_geometry(&self, c_geometry: OGRGeometryH) {
         assert!(!self.has_gdal_ptr());
         assert!(!self.owned);
@@ -388,7 +388,7 @@ impl Geometry {
         if c_spatial_ref.is_null() {
             None
         } else {
-            match SpatialRef::from_c_obj(c_spatial_ref) {
+            match unsafe { SpatialRef::from_c_obj(c_spatial_ref) } {
                 Ok(sr) => Some(sr),
                 Err(_) => None,
             }

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -417,7 +417,7 @@ pub trait LayerAccess: Sized {
         if c_obj.is_null() {
             return Err(_last_null_pointer_err("OGR_L_GetSpatialRef"));
         }
-        SpatialRef::from_c_obj(c_obj)
+        unsafe { SpatialRef::from_c_obj(c_obj) }
     }
 
     fn reset_feature_reading(&mut self) {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

See https://github.com/georust/gdal/pull/257#issuecomment-1096074275