### PR TITLE
'rasterize' should accept references to geometries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Breaking**: Change signature of `gdal::raster::rasterize` method to accept a slice of _references_ to Geometries.
+
+  - https://github.com/georust/gdal/pull/283
+
 - **Breaking**: Add `gdal::vector::OwnedLayer`, `gdal::vector::LayerAccess` and `gdal::vector::layer::OwnedFeatureIterator`. This requires importing `gdal::vector::LayerAccess` for using most vector layer methods.
 
   - https://github.com/georust/gdal/pull/238

--- a/src/raster/rasterize.rs
+++ b/src/raster/rasterize.rs
@@ -162,7 +162,7 @@ mod tests {
 pub fn rasterize(
     dataset: &mut Dataset,
     bands: &[isize],
-    geometries: &[Geometry],
+    geometries: &[&Geometry],
     burn_values: &[f64],
     options: Option<RasterizeOptions>,
 ) -> Result<()> {

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -685,7 +685,7 @@ fn test_rasterize() {
     let mut dataset = driver.create("", rows, cols, 1).unwrap();
 
     let bands = [1];
-    let geometries = [poly];
+    let geometries = [&poly];
     let burn_values = [1.0];
     super::rasterize(&mut dataset, &bands, &geometries, &burn_values, None).unwrap();
 


### PR DESCRIPTION
As of now, `gdal::raster::rasterize` is accepting `&[Geometry]`, but this is a little bit cumbersome, since `gdal::vector::Feature`'s `geometry` method returns a reference `&Geometry`.

To work around, one has to copy the geometry like so:

```rust
...
let geom = feature.geometry();
let wkb = geom.wkb().unwrap();
let copy = Geometry::from_wkb(&wkb);
rasterize(..., &[copy], ...);
```

By changing the `rasterize` function signature to accept a slice of references to geometries, this is not needed anymore.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

