### PR TITLE
prevent SIGSEGV for non-strings on read string method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 - Implemented wrapper for `OGR_L_SetFeature`
 
   - <https://github.com/georust/gdal/pull/264>
-  
+
 - Add `programs::raster::build_vrt`
 - Add `GeoTransformEx` extension trait with `apply` and `invert`
 
@@ -47,7 +47,7 @@
 
   - <https://github.com/georust/gdal/pull/273>
 
-- Add `gdal::srs::CoordTransform::transform_bounds` as wrapper for  `OCTTransformBounds` for GDAL 3.4
+- Add `gdal::srs::CoordTransform::transform_bounds` as wrapper for `OCTTransformBounds` for GDAL 3.4
 
   - <https://github.com/georust/gdal/pull/272>
 
@@ -58,6 +58,10 @@
 - Deprecate `Transaction::dataset` and `Transaction::dataset_mut`. Add `Deref` and `DerefMut` implementations instead.
 
   - <https://github.com/georust/gdal/pull/265>
+
+- Prevent SIGGEGV when reading a string array on an MD Array that is not of type string.
+
+  - <https://github.com/georust/gdal/pull/284>
 
 ## 0.12
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,11 +3,9 @@ use thiserror::Error;
 
 use gdal_sys::{CPLErr, OGRErr, OGRFieldType, OGRwkbGeometryType};
 
-use crate::raster::ExtendedDataType;
-
 pub type Result<T> = std::result::Result<T, GdalError>;
 
-#[derive(Clone, PartialEq, Debug, Error)]
+#[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum GdalError {
     #[error("FfiNulError")]
     FfiNulError(#[from] std::ffi::NulError),
@@ -72,9 +70,11 @@ pub enum GdalError {
     UnlinkMemFile { file_name: String },
     #[error("BadArgument")]
     BadArgument(String),
+
+    #[cfg(all(major_ge_3, minor_ge_1))]
     #[error("Unhandled type '{data_type:?}' on GDAL MD method {method_name}")]
     UnsupportedMdDataType {
-        data_type: ExtendedDataType,
+        data_type: crate::raster::ExtendedDataType,
         method_name: &'static str,
     },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,8 @@ use gdal_sys::{CPLErr, OGRErr, OGRFieldType, OGRwkbGeometryType};
 
 pub type Result<T> = std::result::Result<T, GdalError>;
 
-#[derive(Clone, PartialEq, Eq, Debug, Error)]
+#[allow(unknown_lints, clippy::derive_partial_eq_without_eq)] // only enforce `PartialEq` for `GdalError`
+#[derive(Clone, PartialEq, Debug, Error)]
 pub enum GdalError {
     #[error("FfiNulError")]
     FfiNulError(#[from] std::ffi::NulError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,8 @@ use thiserror::Error;
 
 use gdal_sys::{CPLErr, OGRErr, OGRFieldType, OGRwkbGeometryType};
 
+use crate::raster::ExtendedDataType;
+
 pub type Result<T> = std::result::Result<T, GdalError>;
 
 #[derive(Clone, PartialEq, Debug, Error)]
@@ -70,6 +72,11 @@ pub enum GdalError {
     UnlinkMemFile { file_name: String },
     #[error("BadArgument")]
     BadArgument(String),
+    #[error("Unhandled type '{data_type:?}' on GDAL MD method {method_name}")]
+    UnsupportedMdDataType {
+        data_type: ExtendedDataType,
+        method_name: &'static str,
+    },
 }
 
 /// A wrapper for [`CPLErr::Type`] that reflects it as an enum

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,7 @@ use crate::raster::ExtendedDataType;
 pub type Result<T> = std::result::Result<T, GdalError>;
 
 #[derive(Clone, PartialEq, Debug, Error)]
+#[allow(clippy::derive_partial_eq_without_eq)] // only enforce `PartialEq` for `GdalError`
 pub enum GdalError {
     #[error("FfiNulError")]
     FfiNulError(#[from] std::ffi::NulError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,6 @@ use crate::raster::ExtendedDataType;
 pub type Result<T> = std::result::Result<T, GdalError>;
 
 #[derive(Clone, PartialEq, Debug, Error)]
-#[allow(clippy::derive_partial_eq_without_eq)] // only enforce `PartialEq` for `GdalError`
 pub enum GdalError {
     #[error("FfiNulError")]
     FfiNulError(#[from] std::ffi::NulError),

--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -482,7 +482,7 @@ impl<'a> Dimension<'a> {
 }
 
 /// Wrapper for `GDALExtendedDataType`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExtendedDataType {
     c_data_type: GDALExtendedDataTypeH,
 }

--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -222,6 +222,10 @@ impl<'a> MDArray<'a> {
     pub fn read_as_string_array(&self) -> Result<Vec<String>> {
         let data_type = self.datatype();
         if data_type.class() != GDALExtendedDataTypeClass::GEDTC_STRING {
+            // We have to check that the data type is string.
+            // Only then, GDAL returns an array of string pointers.
+            // Otherwise, we will dereference these string pointers and get a segfault.
+
             return Err(GdalError::UnsupportedMdDataType {
                 data_type,
                 method_name: "GDALMDArrayRead (string)",

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -8,7 +8,7 @@ mod types;
 mod warp;
 
 #[cfg(all(major_ge_3, minor_ge_1))]
-pub use mdarray::{Group, MDArray};
+pub use mdarray::{ExtendedDataType, Group, MDArray};
 pub use rasterband::{
     Buffer, ByteBuffer, CmykEntry, ColorEntry, ColorInterpretation, ColorTable, GrayEntry,
     HlsEntry, PaletteInterpretation, RasterBand, ResampleAlg, RgbaEntry,

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -522,7 +522,7 @@ impl<T: GdalType> Buffer<T> {
 pub type ByteBuffer = Buffer<u8>;
 
 /// Represents a color interpretation of a RasterBand
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ColorInterpretation {
     /// Undefined
     Undefined,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I noticed that there is a segmentation fault when calling read_as_string for the MDArray if it is not of type string.
This is why I check for its datatype first.

Moreover, there are new Clippy lints that I had to consider.