### PR TITLE
enforce that `GdalError` is `Send`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add prebuild bindings for GDAL 3.5
+
   - <https://github.com/georust/gdal/pull/277>
 
 - **Breaking**: Add `gdal::vector::OwnedLayer`, `gdal::vector::LayerAccess` and `gdal::vector::layer::OwnedFeatureIterator`. This requires importing `gdal::vector::LayerAccess` for using most vector layer methods.
@@ -74,6 +75,10 @@
 - Prevent SIGGEGV when reading a string array on an MD Array that is not of type string.
 
   - <https://github.com/georust/gdal/pull/284>
+
+- Test that `GdalError` is `Send`
+
+  - <https://github.com/georust/gdal/pull/293>
 
 ## 0.12
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,9 +72,9 @@ pub enum GdalError {
     BadArgument(String),
 
     #[cfg(all(major_ge_3, minor_ge_1))]
-    #[error("Unhandled type '{data_type:?}' on GDAL MD method {method_name}")]
+    #[error("Unhandled type '{data_type}' on GDAL MD method {method_name}")]
     UnsupportedMdDataType {
-        data_type: crate::raster::ExtendedDataType,
+        data_type: crate::raster::ExtendedDataTypeClass,
         method_name: &'static str,
     },
 }
@@ -97,5 +97,19 @@ impl From<CPLErr::Type> for CplErrType {
         }
 
         unsafe { std::mem::transmute(error_type) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_that_gdal_error_is_send() {
+        fn is_send<T: Send>() -> bool {
+            true
+        }
+
+        assert!(is_send::<GdalError>());
     }
 }

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -8,7 +8,7 @@ mod types;
 mod warp;
 
 #[cfg(all(major_ge_3, minor_ge_1))]
-pub use mdarray::{ExtendedDataType, Group, MDArray};
+pub use mdarray::{ExtendedDataType, ExtendedDataTypeClass, Group, MDArray};
 pub use rasterband::{
     Buffer, ByteBuffer, CmykEntry, ColorEntry, ColorInterpretation, ColorTable, GrayEntry,
     HlsEntry, PaletteInterpretation, RasterBand, ResampleAlg, RgbaEntry,


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Before https://github.com/georust/gdal/pull/284, `GdalError` was `Send`.
The previous PR changed it unknowingly.

This PR changes #284 so that `GdalError` is `Send` again.
Moreover, it adds a test that ensures that.