### PR TITLE
Enabled docs.rs feature gate flag rendering.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,10 @@ trybuild = "1.0"
 
 [workspace]
 members = ["gdal-sys"]
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# include `array` feature in documentation
+features = ["array"]
+# define attribute `docsrs` for feature badges
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ pub enum GdalError {
     #[error("StrUtf8Error")]
     StrUtf8Error(#[from] std::str::Utf8Error),
     #[cfg(feature = "ndarray")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "array")))]
     #[error("NdarrayShapeError")]
     NdarrayShapeError(#[from] ndarray::ShapeError),
     #[error("CPL error class: '{class:?}', error number: '{number}', error msg: '{msg}'")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,9 @@
 //! ...
 //! ```
 
+// Enable `doc_cfg` features when `docsrs` is defined by docs.rs config
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub use version::version_info;
 
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![crate_name = "gdal"]
 #![crate_type = "lib"]
+// Enable `doc_cfg` features when `docsrs` is defined by docs.rs config
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
 //! ## Examples
@@ -170,9 +172,6 @@
 //!       highway=footway
 //! ...
 //! ```
-
-// Enable `doc_cfg` features when `docsrs` is defined by docs.rs config
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use version::version_info;
 

--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -229,6 +229,7 @@ impl<'a> MDArray<'a> {
     }
 
     #[cfg(feature = "ndarray")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "array")))]
     /// Read a 'Array2<T>' from this band. T implements 'GdalType'.
     ///
     /// # Arguments

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -311,6 +311,7 @@ impl<'a> RasterBand<'a> {
     }
 
     #[cfg(feature = "ndarray")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "array")))]
     /// Read a 'Array2<T>' from this band. T implements 'GdalType'.
     ///
     /// # Arguments
@@ -348,6 +349,7 @@ impl<'a> RasterBand<'a> {
     }
 
     #[cfg(feature = "ndarray")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "array")))]
     /// Read a 'Array2<T>' from a 'Dataset' block. T implements 'GdalType'
     /// # Arguments
     /// * block_index - the block index


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Followed approach outlined [here](https://gist.github.com/jam1garner/7d909e1d0e5986b9b8d50830314bec63).

Rendering can be tested locally with:

    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features array --open

Not sure how to test end-to-end (as generated by docs.rs) from a PR.

Closes #228

Sample:

<img width="716" alt="image" src="https://user-images.githubusercontent.com/131013/188246680-914aadf1-4584-459f-a9fd-f49992b86c42.png">
