### PR TITLE
Added `Rasterband::set_no_data` accepting `Option<f64>`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@
 
   - <https://github.com/georust/gdal/pull/303>
 
-- Added ability to delete no-data when `None` is passed to `RasterBand::set_no_data(&mut self, no_data: Option<f64>))`
+- **Breaking** `RasterBand::set_no_data_value` takes `Option<f64>` instead of `f64` so that no _no-data_ can be set.
+  Also makes it symmetric with `RasterBand::no_data_value` which returns `Option<f64>`.
 
   - <https://github.com/georust/gdal/pull/308>
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
   - <https://github.com/georust/gdal/pull/303>
 
+- Added ability to delete no-data when `None` is passed to `RasterBand::set_no_data(&mut self, no_data: Option<f64>))`
+
+  - <https://github.com/georust/gdal/pull/308>
+
+
 ## 0.13
 
 - Add prebuild bindings for GDAL 3.5

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -443,15 +443,13 @@ impl<'a> RasterBand<'a> {
     pub fn set_no_data(&mut self, no_data: Option<f64>) -> Result<()> {
         let rv = if let Some(no_data) = no_data {
             unsafe { gdal_sys::GDALSetRasterNoDataValue(self.c_rasterband, no_data) }
-        }
-        else {
+        } else {
             unsafe { gdal_sys::GDALDeleteRasterNoDataValue(self.c_rasterband) }
         };
 
         if rv != CPLErr::CE_None {
             Err(_last_cpl_err(rv))
-        }
-        else {
+        } else {
             Ok(())
         }
     }

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -432,15 +432,8 @@ impl<'a> RasterBand<'a> {
 
     /// Set the no data value of this band.
     ///
-    /// See [`set_no_data`](Self::set_no_data) for similar function
-    /// where _no-data_ can also be deleted.
-    pub fn set_no_data_value(&mut self, no_data: f64) -> Result<()> {
-        self.set_no_data(Some(no_data))
-    }
-
-    /// Set the no data state of this band.
     /// If `no_data` is `None`, any existing no-data value is deleted.
-    pub fn set_no_data(&mut self, no_data: Option<f64>) -> Result<()> {
+    pub fn set_no_data_value(&mut self, no_data: Option<f64>) -> Result<()> {
         let rv = if let Some(no_data) = no_data {
             unsafe { gdal_sys::GDALSetRasterNoDataValue(self.c_rasterband, no_data) }
         } else {

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -431,12 +431,29 @@ impl<'a> RasterBand<'a> {
     }
 
     /// Set the no data value of this band.
+    ///
+    /// See [`set_no_data`](Self::set_no_data) for similar function
+    /// where _no-data_ can also be deleted.
     pub fn set_no_data_value(&mut self, no_data: f64) -> Result<()> {
-        let rv = unsafe { gdal_sys::GDALSetRasterNoDataValue(self.c_rasterband, no_data) };
-        if rv != CPLErr::CE_None {
-            return Err(_last_cpl_err(rv));
+        self.set_no_data(Some(no_data))
+    }
+
+    /// Set the no data state of this band.
+    /// If `no_data` is `None`, any existing no-data value is deleted.
+    pub fn set_no_data(&mut self, no_data: Option<f64>) -> Result<()> {
+        let rv = if let Some(no_data) = no_data {
+            unsafe { gdal_sys::GDALSetRasterNoDataValue(self.c_rasterband, no_data) }
         }
-        Ok(())
+        else {
+            unsafe { gdal_sys::GDALDeleteRasterNoDataValue(self.c_rasterband) }
+        };
+
+        if rv != CPLErr::CE_None {
+            Err(_last_cpl_err(rv))
+        }
+        else {
+            Ok(())
+        }
     }
 
     /// Returns the color interpretation of this band.

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -557,9 +557,9 @@ fn test_set_no_data_value() {
     let dataset = driver.create("", 20, 10, 1).unwrap();
     let mut rasterband = dataset.rasterband(1).unwrap();
     assert_eq!(rasterband.no_data_value(), None);
-    assert!(rasterband.set_no_data_value(1.23).is_ok());
+    assert!(rasterband.set_no_data_value(Some(1.23)).is_ok());
     assert_eq!(rasterband.no_data_value(), Some(1.23));
-    assert!(rasterband.set_no_data(None).is_ok());
+    assert!(rasterband.set_no_data_value(None).is_ok());
     assert_eq!(rasterband.no_data_value(), None);
 }
 

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -559,6 +559,8 @@ fn test_set_no_data_value() {
     assert_eq!(rasterband.no_data_value(), None);
     assert!(rasterband.set_no_data_value(1.23).is_ok());
     assert_eq!(rasterband.no_data_value(), Some(1.23));
+    assert!(rasterband.set_no_data(None).is_ok());
+    assert_eq!(rasterband.no_data_value(), None);
 }
 
 #[test]


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Closes #275 