### PR TITLE
Made mapping between `ResampleAlg` and `GDALRIOResampleAlg` more direct.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
   - <https://github.com/georust/gdal/pull/303>
 
+- Provided access to `gdal-sys` discriminant values in `ResampleAlg` enum.
+
+  - <https://github.com/georust/gdal/pull/309>
+
 ## 0.13
 
 - Add prebuild bindings for GDAL 3.5


### PR DESCRIPTION
Before the private function `map_resample_alg` was the only way to get the expected GDAL enumeration value.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Before this change, you had to copy `map_resample_alg` (because it was private) when calling into `gdal-sys` functions needing the resampling algorithm (e.g. `GDALAutoCreateWarpedVRT`). Instead of making `pub fn map_resample_alg ...`, took the approach that more tightly binds the C-side types to the Rust enum. Makes the association more clear, and less error prone in the future.