### PR TITLE
Filling out `GDALDataType` metadata and utility support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,9 +36,16 @@
 
   - <https://github.com/georust/gdal/pull/324>
 
+- Added `GdalTypeDescriptor` to provide access to metadata and supporting routines around `GDALDataType` ordinals.
+- **Breaking**: `GDALDataType` is no longer `pub use` in `gdal::raster`, 
+  as `GdalType` and `GdalTypeDescriptor` sufficiently cover use cases in safe code. 
+  Still accessible via `gdal_sys::GDALDataType`.
+
+  - <https://github.com/georust/gdal/pull/318>
+
 ## 0.13
 
-- Add prebuild bindings for GDAL 3.5
+- Add prebuilt bindings for GDAL 3.5
 
   - <https://github.com/georust/gdal/pull/277>
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,9 +36,9 @@
 
   - <https://github.com/georust/gdal/pull/324>
 
-- Added `GdalTypeDescriptor` to provide access to metadata and supporting routines around `GDALDataType` ordinals.
+- Added `GdalDataType` to provide access to metadata and supporting routines around `GDALDataType` ordinals.
 - **Breaking**: `GDALDataType` is no longer `pub use` in `gdal::raster`, 
-  as `GdalType` and `GdalTypeDescriptor` sufficiently cover use cases in safe code. 
+  as `GdalType` and `GdalDataType` sufficiently cover use cases in safe code. 
   Still accessible via `gdal_sys::GDALDataType`.
 
   - <https://github.com/georust/gdal/pull/318>

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -141,7 +141,7 @@ impl Driver {
     /// let ds = d.create("in-memory", 64, 64, 3)?;
     /// assert_eq!(ds.raster_count(), 3);
     /// assert_eq!(ds.raster_size(), (64, 64));
-    /// assert_eq!(ds.rasterband(1)?.band_type(), u8::gdal_type());
+    /// assert_eq!(ds.rasterband(1)?.band_type(), u8::gdal_ordinal());
     /// # Ok(())
     /// # }
     /// ```
@@ -170,7 +170,7 @@ impl Driver {
     /// let ds = d.create_with_band_type::<f64, _>("in-memory", 64, 64, 3)?;
     /// assert_eq!(ds.raster_count(), 3);
     /// assert_eq!(ds.raster_size(), (64, 64));
-    /// assert_eq!(ds.rasterband(1)?.band_type(), f64::gdal_type());
+    /// assert_eq!(ds.rasterband(1)?.band_type(), f64::gdal_ordinal());
     /// # Ok(())
     /// # }
     /// ```
@@ -211,7 +211,7 @@ impl Driver {
     /// ds.set_spatial_ref(&SpatialRef::from_epsg(4326)?)?;
     /// assert_eq!(ds.raster_count(), 1);
     /// assert_eq!(ds.raster_size(), (64, 64));
-    /// assert_eq!(ds.rasterband(1)?.band_type(), u8::gdal_type());
+    /// assert_eq!(ds.rasterband(1)?.band_type(), u8::gdal_ordinal());
     /// assert_eq!(ds.spatial_ref()?.auth_code()?, 4326);
     /// # Ok(())
     /// # }
@@ -255,7 +255,7 @@ impl Driver {
                 size_x as c_int,
                 size_y as c_int,
                 bands as c_int,
-                T::gdal_type(),
+                T::gdal_ordinal(),
                 options_c.as_ptr(),
             )
         };

--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -164,7 +164,7 @@ impl<'a> MDArray<'a> {
         let n_dst_buffer_alloc_size = 0;
 
         let rv = unsafe {
-            let data_type = GDALExtendedDataTypeCreate(T::gdal_type());
+            let data_type = GDALExtendedDataTypeCreate(T::gdal_ordinal());
 
             if !self.datatype().class().is_numeric() {
                 return Err(GdalError::UnsupportedMdDataType {

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -91,7 +91,7 @@ pub use rasterband::{
     StatisticsMinMax,
 };
 pub use rasterize::{rasterize, BurnSource, MergeAlgorithm, OptimizeMode, RasterizeOptions};
-pub use types::{GDALDataType, GdalType};
+pub use types::{GDALDataType, GdalType, GdalTypeDescriptor};
 pub use warp::reproject;
 
 /// Key/value pair for passing driver-specific creation options to

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -91,7 +91,7 @@ pub use rasterband::{
     StatisticsMinMax,
 };
 pub use rasterize::{rasterize, BurnSource, MergeAlgorithm, OptimizeMode, RasterizeOptions};
-pub use types::{AdjustedValue, GDALDataType, GdalType, GdalTypeDescriptor};
+pub use types::{AdjustedValue, GdalType, GdalTypeDescriptor};
 pub use warp::reproject;
 
 /// Key/value pair for passing driver-specific creation options to

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -91,7 +91,7 @@ pub use rasterband::{
     StatisticsMinMax,
 };
 pub use rasterize::{rasterize, BurnSource, MergeAlgorithm, OptimizeMode, RasterizeOptions};
-pub use types::{GDALDataType, GdalType, GdalTypeDescriptor};
+pub use types::{AdjustedValue, GDALDataType, GdalType, GdalTypeDescriptor};
 pub use warp::reproject;
 
 /// Key/value pair for passing driver-specific creation options to

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -91,7 +91,7 @@ pub use rasterband::{
     StatisticsMinMax,
 };
 pub use rasterize::{rasterize, BurnSource, MergeAlgorithm, OptimizeMode, RasterizeOptions};
-pub use types::{AdjustedValue, GdalType, GdalTypeDescriptor};
+pub use types::{AdjustedValue, GdalDataType, GdalType};
 pub use warp::reproject;
 
 /// Key/value pair for passing driver-specific creation options to

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -1,13 +1,14 @@
 use crate::dataset::Dataset;
 use crate::gdal_major_object::MajorObject;
 use crate::metadata::Metadata;
-use crate::raster::{GDALDataType, GdalType};
+use crate::raster::GdalType;
 use crate::utils::{_last_cpl_err, _last_null_pointer_err, _string};
 use gdal_sys::{
     self, CPLErr, GDALColorEntry, GDALColorInterp, GDALColorTableH, GDALComputeRasterMinMax,
-    GDALCreateColorRamp, GDALCreateColorTable, GDALDestroyColorTable, GDALGetPaletteInterpretation,
-    GDALGetRasterStatistics, GDALMajorObjectH, GDALPaletteInterp, GDALRIOResampleAlg, GDALRWFlag,
-    GDALRasterBandH, GDALRasterIOExtraArg, GDALSetColorEntry, GDALSetRasterColorTable,
+    GDALCreateColorRamp, GDALCreateColorTable, GDALDataType, GDALDestroyColorTable,
+    GDALGetPaletteInterpretation, GDALGetRasterStatistics, GDALMajorObjectH, GDALPaletteInterp,
+    GDALRIOResampleAlg, GDALRWFlag, GDALRasterBandH, GDALRasterIOExtraArg, GDALSetColorEntry,
+    GDALSetRasterColorTable,
 };
 use libc::c_int;
 use std::ffi::CString;

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -233,7 +233,7 @@ impl<'a> RasterBand<'a> {
     /// use gdal::raster::{GdalType, ResampleAlg};
     /// let dataset = Dataset::open("fixtures/m_3607824_se_17_1_20160620_sub.tif")?;
     /// let band1 = dataset.rasterband(1)?;
-    /// assert_eq!(band1.band_type(), u8::gdal_type());
+    /// assert_eq!(band1.band_type(), u8::gdal_ordinal());
     /// let size = 4;
     /// let mut buf = vec![0; size*size];
     /// band1.read_into_slice::<u8>((0, 0), band1.size(), (size, size), buf.as_mut_slice(), Some(ResampleAlg::Bilinear))?;
@@ -273,7 +273,7 @@ impl<'a> RasterBand<'a> {
                 buffer.as_mut_ptr() as GDALRasterBandH,
                 size.0 as c_int,
                 size.1 as c_int,
-                T::gdal_type(),
+                T::gdal_ordinal(),
                 0,
                 0,
                 options_ptr,
@@ -303,7 +303,7 @@ impl<'a> RasterBand<'a> {
     /// use gdal::raster::{GdalType, ResampleAlg};
     /// let dataset = Dataset::open("fixtures/m_3607824_se_17_1_20160620_sub.tif")?;
     /// let band1 = dataset.rasterband(1)?;
-    /// assert_eq!(band1.band_type(), u8::gdal_type());
+    /// assert_eq!(band1.band_type(), u8::gdal_ordinal());
     /// let size = 4;
     /// let buf = band1.read_as::<u8>((0, 0), band1.size(), (size, size), Some(ResampleAlg::Bilinear))?;
     /// assert_eq!(buf.size, (size, size));
@@ -347,7 +347,7 @@ impl<'a> RasterBand<'a> {
                 data.as_mut_ptr() as GDALRasterBandH,
                 size.0 as c_int,
                 size.1 as c_int,
-                T::gdal_type(),
+                T::gdal_ordinal(),
                 0,
                 0,
                 options_ptr,
@@ -464,7 +464,7 @@ impl<'a> RasterBand<'a> {
                 buffer.data.as_ptr() as GDALRasterBandH,
                 buffer.size.0 as c_int,
                 buffer.size.1 as c_int,
-                T::gdal_type(),
+                T::gdal_ordinal(),
                 0,
                 0,
             )

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -1,10 +1,7 @@
 use crate::dataset::Dataset;
 use crate::metadata::Metadata;
 use crate::raster::rasterband::ResampleAlg;
-use crate::raster::{
-    ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, RasterCreationOption, StatisticsAll,
-    StatisticsMinMax,
-};
+use crate::raster::{ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, GdalTypeDescriptor, RasterCreationOption, StatisticsAll, StatisticsMinMax};
 use crate::test_utils::TempFixture;
 use crate::vsi::unlink_mem_file;
 use crate::DriverManager;
@@ -891,4 +888,15 @@ fn test_raster_stats() {
             max: 255.0,
         }
     );
+}
+
+#[test]
+fn test_gdal_data_type() {
+    for t in GdalTypeDescriptor::available_types() {
+        // Test converting from GDALDataType:Type
+        let t2: GdalTypeDescriptor = t.gdal_type().try_into().unwrap();
+        assert_eq!(t, &t2, "{}", t);
+        assert!(t.bits() > 0, "{}", t);
+        assert_eq!(t.bits(), t.bytes() * 8, "{}", t);
+    }
 }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -2,8 +2,8 @@ use crate::dataset::Dataset;
 use crate::metadata::Metadata;
 use crate::raster::rasterband::ResampleAlg;
 use crate::raster::{
-    ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, GdalType, GdalTypeDescriptor,
-    RasterCreationOption, StatisticsAll, StatisticsMinMax,
+    ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, RasterCreationOption, StatisticsAll,
+    StatisticsMinMax,
 };
 use crate::test_utils::TempFixture;
 use crate::vsi::unlink_mem_file;
@@ -11,7 +11,6 @@ use crate::DriverManager;
 use gdal_sys::GDALDataType;
 use std::path::Path;
 
-use gdal_sys::GDALDataType::*;
 #[cfg(feature = "ndarray")]
 use ndarray::arr2;
 
@@ -893,76 +892,3 @@ fn test_raster_stats() {
         }
     );
 }
-
-#[test]
-#[allow(non_upper_case_globals)]
-fn test_gdal_data_type() {
-    for t in GdalTypeDescriptor::available_types() {
-        // Test converting from GDALDataType:Type
-        let t2: GdalTypeDescriptor = t.gdal_type().try_into().unwrap();
-        assert_eq!(t, &t2, "{}", t);
-        assert!(t.bits() > 0, "{}", t);
-        assert_eq!(t.bits(), t.bytes() * 8, "{}", t);
-        let name = t.name().unwrap();
-        match t.gdal_type() {
-            GDT_Byte | GDT_UInt16 | GDT_Int16 | GDT_UInt32 | GDT_Int32 => {
-                assert!(t.is_integer(), "{}", &name);
-                assert!(!t.is_floating(), "{}", &name);
-            }
-            GDT_Float32 | GDT_Float64 => {
-                assert!(!t.is_integer(), "{}", &name);
-                assert!(t.is_floating(), "{}", &name);
-            }
-            o => panic!("unknown type ordinal '{}'", o),
-        }
-        match t.gdal_type() {
-            GDT_Byte | GDT_UInt16 | GDT_UInt32 => {
-                assert!(!t.is_signed(), "{}", &name);
-            }
-            GDT_Int16 | GDT_Int32 | GDT_Float32 | GDT_Float64 => {
-                assert!(t.is_signed(), "{}", &name);
-            }
-            o => panic!("unknown type ordinal '{}'", o),
-        }
-    }
-}
-
-#[test]
-fn test_data_type_from_name() {
-    assert!(GdalTypeDescriptor::from_name("foobar").is_err());
-
-    for t in GdalTypeDescriptor::available_types() {
-        let name = t.name().unwrap();
-        let t2 = GdalTypeDescriptor::from_name(&name);
-        assert!(t2.is_ok());
-    }
-}
-
-#[test]
-fn test_data_type_union() {
-    let f32d = <f32>::descriptor();
-    let f64d = <f64>::descriptor();
-
-    let u8d = <u8>::descriptor();
-    let u16d = <u16>::descriptor();
-    let i16d = <i16>::descriptor();
-    let i32d = <i32>::descriptor();
-
-    // reflexivity
-    assert_eq!(i16d.union(i16d), i16d);
-    // symmetry
-    assert_eq!(i16d.union(f32d), f32d);
-    assert_eq!(f32d.union(i16d), f32d);
-    // widening
-    assert_eq!(u8d.union(u16d), u16d);
-    assert_eq!(f32d.union(i32d), f64d);
-
-
-    #[cfg(all(major_ge_3, minor_ge_5))]
-    {
-        let u32d = <u32>::descriptor();
-        let i64d = <i64>::descriptor();
-        assert_eq!(i16d.union(u32d), i64d);
-    }
-}
-

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -905,7 +905,7 @@ fn test_gdal_data_type() {
         assert_eq!(t.bits(), t.bytes() * 8, "{}", t);
         let name = t.name().unwrap();
         match t.gdal_type() {
-            GDT_Byte | GDT_UInt16 | GDT_Int16 | GDT_UInt32 | GDT_Int32 | GDT_UInt64 | GDT_Int64 => {
+            GDT_Byte | GDT_UInt16 | GDT_Int16 | GDT_UInt32 | GDT_Int32 => {
                 assert!(t.is_integer(), "{}", &name);
                 assert!(!t.is_floating(), "{}", &name);
             }
@@ -916,10 +916,10 @@ fn test_gdal_data_type() {
             o => panic!("unknown type ordinal '{}'", o),
         }
         match t.gdal_type() {
-            GDT_Byte | GDT_UInt16 | GDT_UInt32 | GDT_UInt64 => {
+            GDT_Byte | GDT_UInt16 | GDT_UInt32 => {
                 assert!(!t.is_signed(), "{}", &name);
             }
-            GDT_Int16 | GDT_Int32 | GDT_Int64 | GDT_Float32 | GDT_Float64 => {
+            GDT_Int16 | GDT_Int32 | GDT_Float32 | GDT_Float64 => {
                 assert!(t.is_signed(), "{}", &name);
             }
             o => panic!("unknown type ordinal '{}'", o),
@@ -946,11 +946,7 @@ fn test_data_type_union() {
     let u8d = <u8>::descriptor();
     let u16d = <u16>::descriptor();
     let i16d = <i16>::descriptor();
-    let u32d = <u32>::descriptor();
     let i32d = <i32>::descriptor();
-
-    #[cfg(all(major_ge_3, minor_ge_5))]
-    let i64d = <i64>::descriptor();
 
     // reflexivity
     assert_eq!(i16d.union(i16d), i16d);
@@ -960,6 +956,13 @@ fn test_data_type_union() {
     // widening
     assert_eq!(u8d.union(u16d), u16d);
     assert_eq!(f32d.union(i32d), f64d);
+
+
     #[cfg(all(major_ge_3, minor_ge_5))]
-    assert_eq!(i16d.union(u32d), i64d);
+    {
+        let u32d = <u32>::descriptor();
+        let i64d = <i64>::descriptor();
+        assert_eq!(i16d.union(u32d), i64d);
+    }
 }
+

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -85,7 +85,7 @@ impl GdalDataType {
     /// ```
     pub fn for_value<N: GdalType + Into<f64>>(value: N) -> Self {
         let gdal_type = unsafe { GDALFindDataTypeForValue(value.into(), 0) };
-        Self::try_from(gdal_type).unwrap()
+        Self::try_from(gdal_type).expect("GDALFindDataTypeForValue")
     }
 
     /// Get the name of the [`GDALDataType`].
@@ -113,14 +113,14 @@ impl GdalDataType {
     pub fn bits(&self) -> u8 {
         unsafe { GDALGetDataTypeSizeBits(self.gdal_ordinal()) }
             .try_into()
-            .unwrap()
+            .expect("GDALGetDataTypeSizeBits")
     }
 
     /// Get the [`GDALDataType`] size in **bytes**.
     pub fn bytes(&self) -> u8 {
         unsafe { GDALGetDataTypeSizeBytes(self.gdal_ordinal()) }
             .try_into()
-            .unwrap()
+            .expect("GDALGetDataTypeSizeBytes")
     }
 
     /// Returns `true` if [`GDALDataType`] is integral (non-floating point)
@@ -153,7 +153,7 @@ impl GdalDataType {
     /// ```
     pub fn union(&self, other: Self) -> Self {
         let gdal_type = unsafe { GDALDataTypeUnion(self.gdal_ordinal(), other.gdal_ordinal()) };
-        Self::try_from(gdal_type).unwrap()
+        Self::try_from(gdal_type).expect("GDALDataTypeUnion")
     }
 
     /// Change a given value to fit within the constraints of this [`GDALDataType`].
@@ -310,7 +310,7 @@ pub trait GdalType {
     /// ```
     fn datatype() -> GdalDataType {
         // We can call `unwrap` because existence is guaranteed in this case.
-        Self::gdal_ordinal().try_into().unwrap()
+        Self::gdal_ordinal().try_into().expect("GdalDataType")
     }
 }
 

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -1,8 +1,7 @@
 use crate::errors::{GdalError, Result};
 use crate::utils::{_last_null_pointer_err, _string};
-pub use gdal_sys::GDALDataType;
 use gdal_sys::{
-    GDALAdjustValueToDataType, GDALDataTypeIsConversionLossy, GDALDataTypeIsFloating,
+    GDALAdjustValueToDataType, GDALDataType, GDALDataTypeIsConversionLossy, GDALDataTypeIsFloating,
     GDALDataTypeIsInteger, GDALDataTypeIsSigned, GDALDataTypeUnion, GDALFindDataTypeForValue,
     GDALGetDataTypeByName, GDALGetDataTypeName, GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes,
 };

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -2,74 +2,40 @@ use crate::errors::{GdalError, Result};
 use crate::utils::{_last_null_pointer_err, _string};
 pub use gdal_sys::GDALDataType;
 use gdal_sys::{
-    GDALDataTypeIsFloating, GDALDataTypeIsInteger, GDALDataTypeIsSigned, GDALGetDataTypeName,
-    GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes,
+    GDALDataTypeIsFloating, GDALDataTypeIsInteger, GDALDataTypeIsSigned, GDALDataTypeUnion,
+    GDALGetDataTypeByName, GDALGetDataTypeName, GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes,
 };
-use std::fmt::{Display, Formatter};
+use std::ffi::CString;
+use std::fmt::{Debug, Display, Formatter};
 
-/// Type-level constraint for limiting which primitive numeric values can be passed
-/// to functions needing target data type.
-pub trait GdalType {
-    fn gdal_type() -> GDALDataType::Type;
-    fn descriptor() -> GdalTypeDescriptor {
-        // We can call `unwrap` because existence is guaranteed in this case.
-        Self::gdal_type().try_into().unwrap()
-    }
-}
-
-impl GdalType for u8 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_Byte
-    }
-}
-
-impl GdalType for u16 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_UInt16
-    }
-}
-
-impl GdalType for u32 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_UInt32
-    }
-}
-
-impl GdalType for i16 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_Int16
-    }
-}
-
-impl GdalType for i32 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_Int32
-    }
-}
-
-impl GdalType for f32 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_Float32
-    }
-}
-
-impl GdalType for f64 {
-    fn gdal_type() -> GDALDataType::Type {
-        GDALDataType::GDT_Float64
-    }
-}
-
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GdalTypeDescriptor(GDALDataType::Type);
 
 impl GdalTypeDescriptor {
+    /// Find `GDALDataType` by name, as would be returned by [`GdalTypeDescriptor.name()`].
+    #[allow(non_snake_case)]
+    pub fn from_name(name: &str) -> Result<Self> {
+        let c_name = CString::new(name.to_owned())?;
+        let gdal_type = unsafe { GDALGetDataTypeByName(c_name.as_ptr()) };
+        match gdal_type {
+            GDALDataType::GDT_Unknown => Err(GdalError::BadArgument(format!(
+                "unable to find datatype with name '{}'",
+                name
+            ))),
+            _ => gdal_type.try_into(),
+        }
+    }
+
+    /// Get the `GDALDataType` ordinal value
     pub fn gdal_type(&self) -> GDALDataType::Type {
         self.0
     }
+
+    /// Get the name of the `GDALDataType`.
     pub fn name(&self) -> Result<String> {
         let c_str = unsafe { GDALGetDataTypeName(self.gdal_type()) };
         if c_str.is_null() {
-            return Err(_last_null_pointer_err("GDALGetDescription"));
+            return Err(_last_null_pointer_err("GDALGetDataTypeName"));
         }
         Ok(_string(c_str))
     }
@@ -103,6 +69,20 @@ impl GdalTypeDescriptor {
         (unsafe { GDALDataTypeIsSigned(self.gdal_type()) }) > 0
     }
 
+    /// Return the smallest data type that can fully express both `self` and
+    /// `other` data types.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use gdal::raster::GdalType;
+    /// assert_eq!(<f32>::descriptor().union(<i32>::descriptor()), <f64>::descriptor());
+    /// ```
+    pub fn union(&self, other: Self) -> Self {
+        let gdal_type = unsafe { GDALDataTypeUnion(self.gdal_type(), other.gdal_type()) };
+        Self(gdal_type)
+    }
+
     /// Subset of the GDAL data types supported by Rust bindings.
     pub fn available_types() -> &'static [GdalTypeDescriptor] {
         use GDALDataType::*;
@@ -112,11 +92,24 @@ impl GdalTypeDescriptor {
             GdalTypeDescriptor(GDT_Int16),
             GdalTypeDescriptor(GDT_UInt32),
             GdalTypeDescriptor(GDT_Int32),
+            #[cfg(all(major_ge_3, minor_ge_5))]
             GdalTypeDescriptor(GDT_UInt64),
+            #[cfg(all(major_ge_3, minor_ge_5))]
             GdalTypeDescriptor(GDT_Int64),
             GdalTypeDescriptor(GDT_Float32),
             GdalTypeDescriptor(GDT_Float64),
         ]
+    }
+}
+
+impl Debug for GdalTypeDescriptor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GdalTypeDescriptor")
+            .field("name", &self.name().unwrap_or_else(|e| format!("{e:?}")))
+            .field("bits", &self.bits())
+            .field("signed", &self.is_signed())
+            .field("gdal_ordinal", &self.gdal_type())
+            .finish()
     }
 }
 
@@ -138,5 +131,72 @@ impl TryFrom<GDALDataType::Type> for GdalTypeDescriptor {
         } else {
             Ok(wrapped)
         }
+    }
+}
+
+/// Type-level constraint for bounding primitive numeric values passed
+/// to functions requiring a data type. See [`GdalTypeDescriptor`] for access to
+/// metadata describing the data type.
+pub trait GdalType {
+    fn gdal_type() -> GDALDataType::Type;
+    fn descriptor() -> GdalTypeDescriptor {
+        // We can call `unwrap` because existence is guaranteed in this case.
+        Self::gdal_type().try_into().unwrap()
+    }
+}
+
+impl GdalType for u8 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Byte
+    }
+}
+
+impl GdalType for u16 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_UInt16
+    }
+}
+
+impl GdalType for u32 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_UInt32
+    }
+}
+
+#[cfg(all(major_ge_3, minor_ge_5))]
+impl GdalType for u64 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_UInt64
+    }
+}
+
+impl GdalType for i16 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Int16
+    }
+}
+
+impl GdalType for i32 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Int32
+    }
+}
+
+#[cfg(all(major_ge_3, minor_ge_5))]
+impl GdalType for i64 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Int64
+    }
+}
+
+impl GdalType for f32 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Float32
+    }
+}
+
+impl GdalType for f64 {
+    fn gdal_type() -> GDALDataType::Type {
+        GDALDataType::GDT_Float64
     }
 }

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -2,17 +2,39 @@ use crate::errors::{GdalError, Result};
 use crate::utils::{_last_null_pointer_err, _string};
 pub use gdal_sys::GDALDataType;
 use gdal_sys::{
-    GDALDataTypeIsFloating, GDALDataTypeIsInteger, GDALDataTypeIsSigned, GDALDataTypeUnion,
-    GDALGetDataTypeByName, GDALGetDataTypeName, GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes,
+    GDALAdjustValueToDataType, GDALDataTypeIsFloating, GDALDataTypeIsInteger, GDALDataTypeIsSigned,
+    GDALDataTypeUnion, GDALFindDataTypeForValue, GDALGetDataTypeByName, GDALGetDataTypeName,
+    GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes,
 };
 use std::ffi::CString;
 use std::fmt::{Debug, Display, Formatter};
 
+/// Provides ergonomic access to functions describing [`GDALDataType`] ordinals.
+///
+/// A [`GDALDataType`] indicates the primitive storage value of a cell/pixel in a [`RasterBand`][crate::raster::RasterBand].
+///
+/// # Example
+/// ```rust, no_run
+/// use gdal::raster::{GdalType, GdalTypeDescriptor};
+/// let td = <u32>::descriptor();
+/// println!("{} is {} and uses {} bits.",
+///     td.name(),
+///     if td.is_signed() { "signed" } else { "unsigned" },
+///     td.bits()
+/// );
+/// ```
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GdalTypeDescriptor(GDALDataType::Type);
 
 impl GdalTypeDescriptor {
-    /// Find `GDALDataType` by name, as would be returned by [`GdalTypeDescriptor.name()`].
+    /// Find `GdalTypeDescriptor` by name, as would be returned by [`GdalTypeDescriptor.name()`].
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// use gdal::raster::{GdalType, GdalTypeDescriptor};
+    /// assert_eq!(GdalTypeDescriptor::from_name("UInt16").unwrap().gdal_type(), <u16>::gdal_type())
+    /// ```
     #[allow(non_snake_case)]
     pub fn from_name(name: &str) -> Result<Self> {
         let c_name = CString::new(name.to_owned())?;
@@ -26,18 +48,38 @@ impl GdalTypeDescriptor {
         }
     }
 
+    /// Finds the smallest data type able to support the provided value.
+    ///
+    /// See [`GDALFindDataTypeForValue`](https://gdal.org/api/raster_c_api.html#_CPPv424GDALFindDataTypeForValuedi)
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// use gdal::raster::{GdalType, GdalTypeDescriptor};
+    /// assert_eq!(GdalTypeDescriptor::for_value(0), <u8>::descriptor());
+    /// assert_eq!(GdalTypeDescriptor::for_value(256), <u16>::descriptor());
+    /// assert_eq!(GdalTypeDescriptor::for_value(-1), <i16>::descriptor());
+    /// assert_eq!(GdalTypeDescriptor::for_value(<u16>::MAX as f64 * -2.0), <i32>::descriptor());
+    /// ```
+    pub fn for_value<N: GdalType + Into<f64>>(value: N) -> Self {
+        let gdal_type = unsafe { GDALFindDataTypeForValue(value.into(), 0) };
+        GdalTypeDescriptor(gdal_type)
+    }
+
     /// Get the `GDALDataType` ordinal value
     pub fn gdal_type(&self) -> GDALDataType::Type {
         self.0
     }
 
     /// Get the name of the `GDALDataType`.
-    pub fn name(&self) -> Result<String> {
+    pub fn name(&self) -> String {
         let c_str = unsafe { GDALGetDataTypeName(self.gdal_type()) };
         if c_str.is_null() {
-            return Err(_last_null_pointer_err("GDALGetDataTypeName"));
+            // This case shouldn't happen, because `self` only exists for valid
+            // GDALDataType ordinals.
+            panic!("{}", _last_null_pointer_err("GDALGetDataTypeName"));
         }
-        Ok(_string(c_str))
+        _string(c_str)
     }
 
     /// Get the gdal type size in **bits**.
@@ -74,9 +116,13 @@ impl GdalTypeDescriptor {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust, no_run
     /// use gdal::raster::GdalType;
-    /// assert_eq!(<f32>::descriptor().union(<i32>::descriptor()), <f64>::descriptor());
+    /// println!("To safely store all possible '{}' and '{}' values, you should use  '{}'",
+    ///     <f32>::descriptor(),
+    ///     <i32>::descriptor(),
+    ///     <f32>::descriptor().union(<i32>::descriptor())
+    /// );
     /// ```
     pub fn union(&self, other: Self) -> Self {
         let gdal_type = unsafe { GDALDataTypeUnion(self.gdal_type(), other.gdal_type()) };
@@ -105,9 +151,10 @@ impl GdalTypeDescriptor {
 impl Debug for GdalTypeDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GdalTypeDescriptor")
-            .field("name", &self.name().unwrap_or_else(|e| format!("{e:?}")))
+            .field("name", &self.name())
             .field("bits", &self.bits())
             .field("signed", &self.is_signed())
+            .field("floating", &self.is_floating())
             .field("gdal_ordinal", &self.gdal_type())
             .finish()
     }
@@ -115,10 +162,19 @@ impl Debug for GdalTypeDescriptor {
 
 impl Display for GdalTypeDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.name().unwrap())
+        f.write_str(&self.name())
     }
 }
 
+/// Converts from a possible [`GDALDataType`] ordinal value to a [`GdalTypeDescriptor`].
+///
+/// # Example
+///
+/// ```rust, no_run
+/// use gdal::raster::{GdalType, GdalTypeDescriptor};
+/// let gdt: GdalTypeDescriptor = 3.try_into().unwrap();
+/// println!("{gdt:#?}")
+/// ```
 impl TryFrom<GDALDataType::Type> for GdalTypeDescriptor {
     type Error = GdalError;
 
@@ -134,29 +190,66 @@ impl TryFrom<GDALDataType::Type> for GdalTypeDescriptor {
     }
 }
 
-/// Type-level constraint for bounding primitive numeric values passed
-/// to functions requiring a data type. See [`GdalTypeDescriptor`] for access to
-/// metadata describing the data type.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum AdjustedValue {
+    Unchanged(f64),
+    Clamped(f64),
+    Rounded(f64),
+    ClampedRounded(f64),
+}
+
+impl From<AdjustedValue> for f64 {
+    fn from(av: AdjustedValue) -> Self {
+        match av {
+            AdjustedValue::Unchanged(v) => v,
+            AdjustedValue::Clamped(v) => v,
+            AdjustedValue::Rounded(v) => v,
+            AdjustedValue::ClampedRounded(v) => v,
+        }
+    }
+}
+
+/// Type-level constraint for bounding primitive numeric values for generic
+/// functions requiring a data type.
+///
+/// See [`GdalTypeDescriptor`] for access to metadata describing the data type.
 pub trait GdalType {
+    /// Get the [`GDALDataType`] ordinal value used in `gdal_sys` to represent a GDAL cell/pixel
+    /// data type.
+    ///
+    /// See also: [GDAL API](https://gdal.org/api/raster_c_api.html#_CPPv412GDALDataType)
     fn gdal_type() -> GDALDataType::Type;
+
+    /// Get the metadata type over a `GdalType`.
+    ///
+    /// # Example
+    ///
+    /// ```rust, no_run
+    /// use gdal::raster::GdalType;
+    /// let gdt = <u32>::descriptor();
+    /// println!("{gdt:#?}");
+    /// ```
     fn descriptor() -> GdalTypeDescriptor {
         // We can call `unwrap` because existence is guaranteed in this case.
         Self::gdal_type().try_into().unwrap()
     }
 }
 
+/// Provides evidence `u8` is a valid [`GDALDataType`].
 impl GdalType for u8 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Byte
     }
 }
 
+/// Provides evidence `u16` is a valid [`GDALDataType`].
 impl GdalType for u16 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_UInt16
     }
 }
 
+/// Provides evidence `u32` is a valid [`GDALDataType`].
 impl GdalType for u32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_UInt32
@@ -164,18 +257,21 @@ impl GdalType for u32 {
 }
 
 #[cfg(all(major_ge_3, minor_ge_5))]
+/// Provides evidence `u64` is a valid [`GDALDataType`].
 impl GdalType for u64 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_UInt64
     }
 }
 
+/// Provides evidence `i16` is a valid [`GDALDataType`].
 impl GdalType for i16 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Int16
     }
 }
 
+/// Provides evidence `i32` is a valid [`GDALDataType`].
 impl GdalType for i32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Int32
@@ -183,20 +279,126 @@ impl GdalType for i32 {
 }
 
 #[cfg(all(major_ge_3, minor_ge_5))]
+/// Provides evidence `i64` is a valid [`GDALDataType`].
 impl GdalType for i64 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Int64
     }
 }
 
+/// Provides evidence `f32` is a valid [`GDALDataType`].
 impl GdalType for f32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Float32
     }
 }
 
+/// Provides evidence `f64` is a valid [`GDALDataType`].
 impl GdalType for f64 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Float64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gdal_sys::GDALDataType::*;
+    use crate::raster::types::AdjustedValue::{ClampedRounded, Rounded};
+
+    #[test]
+    #[allow(non_upper_case_globals)]
+    fn test_gdal_data_type() {
+        for t in GdalTypeDescriptor::available_types() {
+            // Test converting from GDALDataType:Type
+            let t2: GdalTypeDescriptor = t.gdal_type().try_into().unwrap();
+            assert_eq!(t, &t2, "{}", t);
+            assert!(t.bits() > 0, "{}", t);
+            assert_eq!(t.bits(), t.bytes() * 8, "{}", t);
+            let name = t.name();
+            match t.gdal_type() {
+                GDT_Byte | GDT_UInt16 | GDT_Int16 | GDT_UInt32 | GDT_Int32 => {
+                    assert!(t.is_integer(), "{}", &name);
+                    assert!(!t.is_floating(), "{}", &name);
+                }
+                #[cfg(all(major_ge_3, minor_ge_5))]
+                GDT_UInt64 | GDT_Int64 => {
+                    assert!(t.is_integer(), "{}", &name);
+                    assert!(!t.is_floating(), "{}", &name);
+                }
+                GDT_Float32 | GDT_Float64 => {
+                    assert!(!t.is_integer(), "{}", &name);
+                    assert!(t.is_floating(), "{}", &name);
+                }
+
+                o => panic!("unknown type ordinal '{}'", o),
+            }
+            match t.gdal_type() {
+                GDT_Byte | GDT_UInt16 | GDT_UInt32 => {
+                    assert!(!t.is_signed(), "{}", &name);
+                }
+                #[cfg(all(major_ge_3, minor_ge_5))]
+                GDT_UInt64 => {
+                    assert!(!t.is_signed(), "{}", &name);
+                }
+                GDT_Int16 | GDT_Int32 | GDT_Float32 | GDT_Float64 => {
+                    assert!(t.is_signed(), "{}", &name);
+                }
+                #[cfg(all(major_ge_3, minor_ge_5))]
+                GDT_Int64 => {
+                    assert!(t.is_signed(), "{}", &name);
+                }
+                o => panic!("unknown type ordinal '{}'", o),
+            }
+        }
+    }
+
+    #[test]
+    fn test_data_type_from_name() {
+        assert!(GdalTypeDescriptor::from_name("foobar").is_err());
+
+        for t in GdalTypeDescriptor::available_types() {
+            let name = t.name();
+            let t2 = GdalTypeDescriptor::from_name(&name);
+            assert!(t2.is_ok());
+        }
+    }
+
+    #[test]
+    fn test_data_type_union() {
+        let f32d = <f32>::descriptor();
+        let f64d = <f64>::descriptor();
+
+        let u8d = <u8>::descriptor();
+        let u16d = <u16>::descriptor();
+        let i16d = <i16>::descriptor();
+        let i32d = <i32>::descriptor();
+
+        // reflexivity
+        assert_eq!(i16d.union(i16d), i16d);
+        // symmetry
+        assert_eq!(i16d.union(f32d), f32d);
+        assert_eq!(f32d.union(i16d), f32d);
+        // widening
+        assert_eq!(u8d.union(u16d), u16d);
+        assert_eq!(f32d.union(i32d), f64d);
+
+        #[cfg(all(major_ge_3, minor_ge_5))]
+        {
+            let u32d = <u32>::descriptor();
+            let i64d = <i64>::descriptor();
+            assert_eq!(i16d.union(u32d), i64d);
+        }
+    }
+
+    #[test]
+    fn test_for_value() {
+        assert_eq!(GdalTypeDescriptor::for_value(0), <u8>::descriptor());
+        assert_eq!(GdalTypeDescriptor::for_value(256), <u16>::descriptor());
+        assert_eq!(GdalTypeDescriptor::for_value(-1), <i16>::descriptor());
+        assert_eq!(
+            GdalTypeDescriptor::for_value(<u16>::MAX as f64 * -2.0),
+            <i32>::descriptor()
+        );
     }
 }

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -1,7 +1,17 @@
+use std::fmt::{Display, Formatter};
 pub use gdal_sys::GDALDataType;
+use gdal_sys::{GDALGetDataTypeName, GDALGetDataTypeSizeBits, GDALGetDataTypeSizeBytes};
+use crate::errors::{GdalError, Result};
+use crate::utils::{_last_null_pointer_err, _string};
 
+/// Type-level constraint for limiting which primitive numeric values can be passed
+/// to functions needing target data type.
 pub trait GdalType {
     fn gdal_type() -> GDALDataType::Type;
+    fn descriptor() -> GdalTypeDescriptor {
+        // We can call `unwrap` because existence is guaranteed in this case.
+        Self::gdal_type().try_into().unwrap()
+    }
 }
 
 impl GdalType for u8 {
@@ -9,33 +19,101 @@ impl GdalType for u8 {
         GDALDataType::GDT_Byte
     }
 }
+
 impl GdalType for u16 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_UInt16
     }
 }
+
 impl GdalType for u32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_UInt32
     }
 }
+
 impl GdalType for i16 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Int16
     }
 }
+
 impl GdalType for i32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Int32
     }
 }
+
 impl GdalType for f32 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Float32
     }
 }
+
 impl GdalType for f64 {
     fn gdal_type() -> GDALDataType::Type {
         GDALDataType::GDT_Float64
     }
 }
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GdalTypeDescriptor(GDALDataType::Type);
+
+impl GdalTypeDescriptor {
+    pub fn gdal_type(&self) -> GDALDataType::Type {
+        self.0
+    }
+    pub fn name(&self) -> Result<String> {
+        let c_str = unsafe { GDALGetDataTypeName(self.gdal_type()) };
+        if c_str.is_null() {
+            return Err(_last_null_pointer_err("GDALGetDescription"));
+        }
+        Ok(_string(c_str))
+    }
+
+    /// Get the gdal type size in **bits**.
+    pub fn bits(&self) -> u8 {
+        unsafe { GDALGetDataTypeSizeBits(self.gdal_type()) }.try_into().unwrap()
+    }
+
+    /// Get the gdal type size in **bytes**.
+    pub fn bytes(&self) -> u8 {
+        unsafe { GDALGetDataTypeSizeBytes(self.gdal_type()) }.try_into().unwrap()
+    }
+
+    /// Subset of the GDAL data types supported by Rust bindings.
+    pub fn available_types() -> &'static [GdalTypeDescriptor] {
+        use GDALDataType::*;
+        &[
+            GdalTypeDescriptor(GDT_Byte),
+            GdalTypeDescriptor(GDT_UInt16),
+            GdalTypeDescriptor(GDT_Int16),
+            GdalTypeDescriptor(GDT_UInt32),
+            GdalTypeDescriptor(GDT_Int32),
+            GdalTypeDescriptor(GDT_UInt64),
+            GdalTypeDescriptor(GDT_Int64),
+            GdalTypeDescriptor(GDT_Float32),
+            GdalTypeDescriptor(GDT_Float64)
+        ]
+    }
+}
+
+impl Display for GdalTypeDescriptor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name().unwrap())
+    }
+}
+
+impl TryFrom<GDALDataType::Type> for GdalTypeDescriptor {
+    type Error = GdalError;
+
+    fn try_from(value: GDALDataType::Type) -> std::result::Result<Self, Self::Error> {
+        let wrapped = GdalTypeDescriptor(value);
+        if !GdalTypeDescriptor::available_types().contains(&wrapped) {
+            Err(GdalError::BadArgument(format!("unknown GDALDataType {value}")))
+        } else {
+            Ok(wrapped)
+        }
+    }
+}
+

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -487,14 +487,8 @@ mod tests {
         assert_eq!(<u8>::datatype().adjust_value(1.2334), Rounded(1.));
         assert_eq!(<u8>::datatype().adjust_value(1000.2334), Clamped(255.));
         assert_eq!(<u8>::datatype().adjust_value(-1), Clamped(0.));
-        assert_eq!(
-            <i16>::datatype().adjust_value(-32768),
-            Unchanged(-32768.0)
-        );
-        assert_eq!(
-            <i16>::datatype().adjust_value(-32767.4),
-            Rounded(-32767.0)
-        );
+        assert_eq!(<i16>::datatype().adjust_value(-32768), Unchanged(-32768.0));
+        assert_eq!(<i16>::datatype().adjust_value(-32767.4), Rounded(-32767.0));
         assert_eq!(
             <f32>::datatype().adjust_value(1e300),
             Clamped(f32::MAX as f64)

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -14,7 +14,7 @@ use std::fmt::{Debug, Display, Formatter};
 ///
 /// # Example
 /// ```rust, no_run
-/// use gdal::raster::{GdalType, GdalDataType};
+/// use gdal::raster::GdalType;
 /// let td = <u32>::datatype();
 /// println!("{} is {} and uses {} bits.",
 ///     td.name(),
@@ -253,7 +253,7 @@ impl Display for GdalDataType {
 /// # Example
 ///
 /// ```rust, no_run
-/// use gdal::raster::{GdalType, GdalDataType};
+/// use gdal::raster::GdalDataType;
 /// let gdt: GdalDataType = 3.try_into().unwrap();
 /// println!("{gdt:#?}")
 /// ```
@@ -276,9 +276,12 @@ impl TryFrom<u32> for GdalDataType {
             GDT_Int64 => Ok(GdalDataType::Int64),
             GDT_Float32 => Ok(GdalDataType::Float32),
             GDT_Float64 => Ok(GdalDataType::Float64),
-            GDT_CInt16 | GDT_CInt32 | GDT_CFloat32 | GDT_CFloat64 =>
-                Err(GdalError::BadArgument("Complex data types are not available".into())),
-            o => Err(GdalError::BadArgument(format!("unknown GDALDataType ordinal' {o}'")))
+            GDT_CInt16 | GDT_CInt32 | GDT_CFloat32 | GDT_CFloat64 => Err(GdalError::BadArgument(
+                "Complex data types are not available".into(),
+            )),
+            o => Err(GdalError::BadArgument(format!(
+                "unknown GDALDataType ordinal' {o}'"
+            ))),
         }
     }
 }
@@ -450,7 +453,6 @@ mod tests {
         for t in [GDT_CInt16, GDT_CInt32, GDT_CFloat32, GDT_CFloat64] {
             assert!(TryInto::<GdalDataType>::try_into(t).is_err());
         }
-
     }
 
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Primarily adds `GdalTypeDescriptor` for enabling runtime inspection of `GDALDataType` properties.

**Note, potentially breaking change**: `GDALDataType` is no longer `pub use` in `gdal::raster`, 
  as `GdalType` and `GdalTypeDescriptor` sufficiently cover use cases in safe code. 
  Still accessible via `gdal_sys::GDALDataType`.

---

<img width="740" alt="image" src="https://user-images.githubusercontent.com/131013/197398449-e0c1f448-87ee-498f-b1c2-33625b08c653.png">
