### PR TITLE
Wait for `osgeo/gdal` tests to complete

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,12 @@
 status = [
+    "ci gdal-35",
+    "ci gdal-35 (--all-features)",
+    "ci gdal-34",
+    "ci gdal-34 (--all-features)",
+    "ci gdal-33",
+    "ci gdal-33 (--all-features)",
+    "ci gdal-32",
+    "ci gdal-32 (--all-features)",
     "ci ubuntu-lts",
     "ci ubuntu-lts (--all-features)"
 ]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Not sure if this was intentional or not, but it seems like a good idea to wait at least for one of those versions.

And we should probably have a policy for which versions we test on.