### PR TITLE
Consolidated `fixture!` implementation and enabled usage anywhere in module structure.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@
 dto = "test --doc -- --show-output"
 # Run clippy, raising warnings to errors
 nowarn = "clippy --all-targets -- -D warnings"
+[env]
+# Used by `fixture!` macro.
+FIXTURES_DIR = { value = "fixtures", relative = true }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -1083,22 +1083,9 @@ impl<'a> Drop for Transaction<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fixture;
     use crate::vector::{Geometry, LayerAccess};
     use tempfile::TempPath;
-
-    macro_rules! fixture {
-        ($name:expr) => {
-            Path::new(file!())
-                .parent()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .join("fixtures")
-                .as_path()
-                .join($name)
-                .as_path()
-        };
-    }
 
     /// Copies the given file to a temporary file and opens it for writing. When the returned
     /// `TempPath` is dropped, the file is deleted.
@@ -1237,7 +1224,7 @@ mod tests {
     #[test]
     fn test_create_layer_options() {
         use gdal_sys::OGRwkbGeometryType::wkbPoint;
-        let (_temp_path, mut ds) = open_gpkg_for_update(fixture!("poly.gpkg"));
+        let (_temp_path, mut ds) = open_gpkg_for_update(&fixture!("poly.gpkg"));
         let mut options = LayerOptions {
             name: "new",
             ty: wkbPoint,
@@ -1251,14 +1238,14 @@ mod tests {
 
     #[test]
     fn test_start_transaction() {
-        let (_temp_path, mut ds) = open_gpkg_for_update(fixture!("poly.gpkg"));
+        let (_temp_path, mut ds) = open_gpkg_for_update(&fixture!("poly.gpkg"));
         let txn = ds.start_transaction();
         assert!(txn.is_ok());
     }
 
     #[test]
     fn test_transaction_commit() {
-        let (_temp_path, mut ds) = open_gpkg_for_update(fixture!("poly.gpkg"));
+        let (_temp_path, mut ds) = open_gpkg_for_update(&fixture!("poly.gpkg"));
         let orig_feature_count = ds.layer(0).unwrap().feature_count();
 
         let txn = ds.start_transaction().unwrap();
@@ -1271,7 +1258,7 @@ mod tests {
 
     #[test]
     fn test_transaction_rollback() {
-        let (_temp_path, mut ds) = open_gpkg_for_update(fixture!("poly.gpkg"));
+        let (_temp_path, mut ds) = open_gpkg_for_update(&fixture!("poly.gpkg"));
         let orig_feature_count = ds.layer(0).unwrap().feature_count();
 
         let txn = ds.start_transaction().unwrap();
@@ -1284,7 +1271,7 @@ mod tests {
 
     #[test]
     fn test_transaction_implicit_rollback() {
-        let (_temp_path, mut ds) = open_gpkg_for_update(fixture!("poly.gpkg"));
+        let (_temp_path, mut ds) = open_gpkg_for_update(&fixture!("poly.gpkg"));
         let orig_feature_count = ds.layer(0).unwrap().feature_count();
 
         {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -42,3 +42,10 @@ impl AsRef<Path> for TempFixture {
         self.path()
     }
 }
+
+#[macro_export]
+macro_rules! fixture {
+    ($name:expr) => {
+        std::path::Path::new(env!("FIXTURES_DIR")).join($name)
+    };
+}

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -3,28 +3,9 @@ use super::{
     OGRwkbGeometryType, OwnedLayer,
 };
 use crate::spatial_ref::SpatialRef;
-use crate::{assert_almost_eq, Dataset, DatasetOptions, GdalOpenFlags};
+use crate::{assert_almost_eq, fixture, Dataset, DatasetOptions, GdalOpenFlags};
 mod convert_geo;
 mod sql;
-
-#[macro_export]
-macro_rules! fixture {
-    ($name:expr) => {
-        std::path::Path::new(file!())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("fixtures")
-            .as_path()
-            .join($name)
-            .as_path()
-    };
-}
 
 #[test]
 fn test_layer_count() {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

There were two versions of `fixture!`, and was working on a PR that needed a third, so this simplifies and consolidates the implementation by making use of relative paths in `[env]` section of `config.toml`.
