### PR TITLE
Handling cases where feature may not have any geometry at all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Breaking**: `Feature::geometry` returns an `Option<&Geometry>` instead of `&Geometry`. Calls to `Feature::geometry` will no longer panic.
+
+  - <https://github.com/georust/gdal/pull/349>
+
 - **Breaking**: `RasterBand::band_type` returns the `GdalDataType` enum instead of `GDALDataType::Type` ordinal. Fixes [#333](https://github.com/georust/gdal/issues/333)
 
   - <https://github.com/georust/gdal/pull/334>

--- a/examples/read_write_ogr.rs
+++ b/examples/read_write_ogr.rs
@@ -39,13 +39,18 @@ fn run() -> Result<()> {
     let defn = Defn::from_layer(&lyr);
 
     for feature_a in layer_a.features() {
-        // Get the original geometry:
-        let geom = feature_a.geometry();
-        // Get a new transformed geometry:
-        let new_geom = geom.transform(&htransform)?;
-        // Create the new feature, set its geometry:
+        // Create the new feature
         let mut ft = Feature::new(&defn)?;
-        ft.set_geometry(new_geom)?;
+
+        // Get the original geometry
+        if let Some(geom) = feature_a.geometry() {
+            // Get a new transformed geometry:
+            let new_geom = geom.transform(&htransform)?;
+
+            // Set the new feature's geometry
+            ft.set_geometry(new_geom)?;
+        }
+
         // copy each field value of the feature:
         for fd in &fields_defn {
             if let Some(value) = feature_a.field(&fd.0)? {

--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -31,7 +31,9 @@ fn run() -> gdal::errors::Result<()> {
 
     for feature_a in layer_a.features() {
         let mut ft = Feature::new(&defn)?;
-        ft.set_geometry(feature_a.geometry().clone())?;
+        if let Some(geom) = feature_a.geometry() {
+            ft.set_geometry(geom.clone())?;
+        }
         // copy each field value of the feature:
         for field in defn.fields() {
             ft.set_field(

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -450,10 +450,10 @@ impl<'a> Feature<'a> {
     }
 
     /// Get the feature's geometry.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// This function will panic if the feature does not have any geometry. 
+    ///
+    /// This function will panic if the feature does not have any geometry.
     /// When working with data that may not have geometry use the `has_geometry` function to guard calls to `geometry`.
     pub fn geometry(&self) -> &Geometry {
         if self.geometry.is_empty() {
@@ -468,8 +468,8 @@ impl<'a> Feature<'a> {
     }
 
     /// Check if this feature has geometry
-    pub fn has_geometry(&self) -> bool{
-        return self.geometry.len() > 0
+    pub fn has_geometry(&self) -> bool {
+        return self.geometry.len() > 0;
     }
 
     pub fn geometry_by_name(&self, field_name: &str) -> Result<&Geometry> {

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -469,7 +469,7 @@ impl<'a> Feature<'a> {
 
     /// Check if this feature has geometry
     pub fn has_geometry(&self) -> bool {
-        return self.geometry.len() > 0;
+        !self.geometry.is_empty()
     }
 
     pub fn geometry_by_name(&self, field_name: &str) -> Result<&Geometry> {

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -26,7 +26,7 @@
 //!         // need random access.
 //!         let fid = feature.fid().unwrap_or(0);
 //!         // Summarize the geometry
-//!         let geometry = feature.geometry();
+//!         let geometry = feature.geometry().unwrap();
 //!         let geom_type = geometry_type_to_name(geometry.geometry_type());
 //!         let geom_len = geometry.get_point_vec().len();
 //!         println!("    Feature fid={fid:?}, geometry_type='{geom_type}', geometry_len={geom_len}");

--- a/src/vector/vector_tests/mod.rs
+++ b/src/vector/vector_tests/mod.rs
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn test_geom_accessors() {
         with_feature("roads.geojson", 236194095, |feature| {
-            let geom = feature.geometry();
+            let geom = feature.geometry().unwrap();
             assert_eq!(geom.geometry_type(), OGRwkbGeometryType::wkbLineString);
             let coords = geom.get_point_vec();
             assert_eq!(
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn test_wkt() {
         with_feature("roads.geojson", 236194095, |feature| {
-            let wkt = feature.geometry().wkt().unwrap();
+            let wkt = feature.geometry().unwrap().wkt().unwrap();
             let wkt_ok = format!(
                 "{}{}",
                 "LINESTRING (26.1019276 44.4302748,",
@@ -615,7 +615,7 @@ mod tests {
     #[test]
     fn test_json() {
         with_feature("roads.geojson", 236194095, |feature| {
-            let json = feature.geometry().json();
+            let json = feature.geometry().unwrap().json();
             let json_ok = format!(
                 "{}{}{}{}",
                 "{ \"type\": \"LineString\", \"coordinates\": [ ",
@@ -793,7 +793,7 @@ mod tests {
             let ds = Dataset::open(fixture!("output.geojson")).unwrap();
             let mut layer = ds.layer(0).unwrap();
             let ft = layer.features().next().unwrap();
-            assert_eq!(ft.geometry().wkt().unwrap(), "POINT (1 2)");
+            assert_eq!(ft.geometry().unwrap().wkt().unwrap(), "POINT (1 2)");
             assert_eq!(
                 ft.field("Name").unwrap().unwrap().into_string(),
                 Some("Feature 1".to_string())


### PR DESCRIPTION
- [✓] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [✓] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I've run into a few instances where I'm loading data uploaded from users (for example CSV files) where GDAL isn't able to find any geometry.  In instances where you might be working with user-provided data with no geometry, calls to `Feature::geometry()` simply panic. 

This PR documents renders `Feature::geometry` non-panicking by returning an `Option<&Geometry>`