### PR TITLE
Changed return type of Layer::spatial_ref from `Result` to `Option`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@
 
 - Added prebuilt bindings for GDAL 3.6 (released 6 November 2022).
 
+  - <https://github.com/georust/gdal/pull/352>
+
+- **Breaking**: `Layer::spatial_ref` returns `Option` instead of `Result`, thereby better reflecting the semantics documented in the [C++ API](https://gdal.org/doxygen/classOGRLayer.html#a75c06b4993f8eb76b569f37365cd19ab)
+
+  - <https://github.com/georust/gdal/pull/355>
+
 ## 0.14
 
 - Added new content to `README.md` and the root docs.

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -418,13 +418,16 @@ pub trait LayerAccess: Sized {
 
     /// Fetch the spatial reference system for this layer.
     ///
+    /// Returns `Some(SpatialRef)`, or `None` if one isn't defined.
+    ///
     /// Refer [OGR_L_GetSpatialRef](https://gdal.org/doxygen/classOGRLayer.html#a75c06b4993f8eb76b569f37365cd19ab)
-    fn spatial_ref(&self) -> Result<SpatialRef> {
+    fn spatial_ref(&self) -> Option<SpatialRef> {
         let c_obj = unsafe { gdal_sys::OGR_L_GetSpatialRef(self.c_layer()) };
         if c_obj.is_null() {
-            return Err(_last_null_pointer_err("OGR_L_GetSpatialRef"));
+            None
+        } else {
+            unsafe { SpatialRef::from_c_obj(c_obj) }.ok()
         }
-        unsafe { SpatialRef::from_c_obj(c_obj) }
     }
 
     fn reset_feature_reading(&mut self) {


### PR DESCRIPTION
Fixes #248.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

