### PR TITLE
Add CslStringList::add_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added `CslStringList::add_string`
+
+  - <https://github.com/georust/gdal/pull/364>
+
 - **Possibly breaking**: Set MSRV to 1.58.
 
   - <https://github.com/georust/gdal/pull/363>


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This method wraps gdal_sys::CSLAddString.

This method is useful when constructing argument lists for option structs for the various utility functions found in gdal_utils, such as GDALWarp and GDALTranslate.
