### PR TITLE
Implement CoordTransformOptions and CoordTransform::new_with_options constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added `CoordTransform::new_with_options` and `CoordTransformOptions`
+
+  - <https://github.com/georust/gdal/pull/372>
+
 - Set the link flag of gdal-sys to "libgdal". Emit the libgdal version via cargo:version_number. Remove wrong build-dependency on gdal-sys and remove docs_rs workaround.
 
   - <https://github.com/georust/gdal/pull/377>


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I only needed this for the ballpark option, because I found it surprising that it's possible by default to transform between CRSes that are only valid on opposite sides of the world. I didn't change this default though.

The other three options are wrapped, but I don't understand them well enough to add tests for them.