### PR TITLE
Fix transform_bounds docstring (min/max confusion)

### DIFF
--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -37,7 +37,7 @@ impl CoordTransform {
     /// transformations.
     ///
     /// # Arguments
-    /// * `bounds` - array of [axis0_min, axis1_min, axis0_max, axis1_min],
+    /// * `bounds` - array of [axis0_min, axis1_min, axis0_max, axis1_max],
     ///            interpreted in the axis order of the source SpatialRef,
     ///            typically [xmin, ymin, xmax, ymax]
     /// * `densify_pts` - number of points per edge (recommended: 21)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This fixes a small typo in the `transform_bounds` docstring.
