### PR TITLE
GHA Workflow for running tests under a more strict memory checking environment

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -8,7 +8,7 @@ jobs:
   cargo-careful:
     runs-on: ubuntu-latest
     container:
-      image: osgeo/gdal:ubuntu-full-3.6.0
+      image: ghcr.io/osgeo/gdal:ubuntu-full-3.6.4
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install cargo-careful
         run: |
           export CAREFUL=${CARGO_HOME:-$HOME/.cargo}/bin/cargo-careful
-          curl -L https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl > "${CAREFUL}"
+          curl -Lo ~/.cargo/bin/cargo-careful https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl
           chmod +x "${CAREFUL}"
           cargo careful setup
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,11 +1,11 @@
-name: Sanitizers
+name: Sanitize
 
 on:
-  pull_request: {}
-  workflow_dispatch: {}
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  address:
+  cargo-careful:
     runs-on: ubuntu-latest
     container:
       image: osgeo/gdal:ubuntu-full-3.6.0
@@ -30,26 +30,17 @@ jobs:
         run: |
           rustup toolchain install nightly --profile minimal --component rust-src
           rustup override set nightly
-          cargo install cargo-careful
 
       - name: Get target triple
         run: |
           echo "TARGET=$(rustc -vV | awk '/^host: / { print $2 }')" >>${GITHUB_ENV}
 
-      - name: Run test with address sanitizer
+      - name: Run tests with careful
         env:
-          RUSTFLAGS: -Z sanitizer=address
-          RUSTDOCFLAGS: -Z sanitizer=address
+          # See: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags
           # Note: because we don't build GDAL with sanitizers, we need to turn off
           # leak detection, otherwise it'll report memory leak false positives
           ASAN_OPTIONS: verbose=1:atexit=1:detect_stack_use_after_return=1:strict_string_checks=1:detect_leaks=0
-        run: cargo test -Zbuild-std --all --target ${{ env.TARGET }}
-
-      - name: Run tests with memory sanitizer
-        env:
-          RUSTFLAGS: -Z sanitizer=memory
-          RUSTDOCFLAGS: -Z sanitizer=memory
-        run: cargo test -Zbuild-std --target ${{ env.TARGET }}
-
-      - name: Run tests with careful
-        run: cargo careful test --all -Zcareful-sanitizer
+        run: |
+          cargo install cargo-careful
+          cargo careful test -Zbuild-std --all -Zcareful-sanitizer

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -2,6 +2,9 @@ name: Sanitize
 
 on: workflow_dispatch
 
+env:
+  CAREFUL_VER: v0.3.4
+
 jobs:
   cargo-careful:
     runs-on: ubuntu-latest
@@ -34,7 +37,7 @@ jobs:
       - name: Install cargo-careful
         run: |
           CAREFUL=${HOME}/.cargo/bin/cargo-careful
-          curl -Lo "${CAREFUL}" https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl
+          curl -Lo "${CAREFUL}" https://github.com/RalfJung/cargo-careful/releases/download/${CAREFUL_VER}/cargo-careful.x86_64-unknown-linux-musl
           chmod +x "${CAREFUL}"
           cargo careful setup
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,8 +1,6 @@
 name: Sanitize
 
-on:
-#  pull_request:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   cargo-careful:
@@ -21,7 +19,7 @@ jobs:
           apt-get update -y
           apt-get install build-essential pkg-config libclang-dev curl -y
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --profile minimal --default-toolchain none -y
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
       - name: Setup building
         run: |
@@ -35,8 +33,8 @@ jobs:
 
       - name: Install cargo-careful
         run: |
-          export CAREFUL=${CARGO_HOME:-$HOME/.cargo}/bin/cargo-careful
-          curl -Lo ~/.cargo/bin/cargo-careful https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl
+          CAREFUL=${HOME}/.cargo/bin/cargo-careful
+          curl -Lo "${CAREFUL}" https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl
           chmod +x "${CAREFUL}"
           cargo careful setup
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,7 +1,7 @@
 name: Sanitize
 
 on:
-  pull_request:
+#  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -13,11 +13,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: Install build deps
         shell: bash
+        # Note: clang, etc. are needed so cargo-careful can build std with extra checks enabled
         run: |
           apt-get update -y
-          apt-get install build-essential curl pkg-config libclang-dev -y
+          apt-get install build-essential pkg-config libclang-dev curl -y
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --profile minimal --default-toolchain none -y
           echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
 
@@ -31,16 +33,18 @@ jobs:
           rustup toolchain install nightly --profile minimal --component rust-src
           rustup override set nightly
 
-      - name: Get target triple
+      - name: Install cargo-careful
         run: |
-          echo "TARGET=$(rustc -vV | awk '/^host: / { print $2 }')" >>${GITHUB_ENV}
+          export CAREFUL=${CARGO_HOME:-$HOME/.cargo}/bin/cargo-careful
+          curl -L https://github.com/RalfJung/cargo-careful/releases/download/v0.3.4/cargo-careful.x86_64-unknown-linux-musl > "${CAREFUL}"
+          chmod +x "${CAREFUL}"
+          cargo careful setup
 
       - name: Run tests with careful
         env:
           # See: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags
           # Note: because we don't build GDAL with sanitizers, we need to turn off
           # leak detection, otherwise it'll report memory leak false positives
-          ASAN_OPTIONS: verbose=1:atexit=1:detect_stack_use_after_return=1:strict_string_checks=1:detect_leaks=0
+          ASAN_OPTIONS: verbose=0:atexit=1:detect_stack_use_after_return=1:strict_string_checks=1:detect_leaks=0
         run: |
-          cargo install cargo-careful
           cargo careful test -Zbuild-std --all -Zcareful-sanitizer

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,0 +1,55 @@
+name: Sanitizers
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  address:
+    runs-on: ubuntu-latest
+    container:
+      image: osgeo/gdal:ubuntu-full-3.6.0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install build deps
+        shell: bash
+        run: |
+          apt-get update -y
+          apt-get install build-essential curl pkg-config libclang-dev -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --profile minimal --default-toolchain none -y
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+
+      - name: Setup building
+        run: |
+          export CC="clang-9"
+          export CXX="clang++-9"
+
+      - name: Install Rust nightly
+        run: |
+          rustup toolchain install nightly --profile minimal --component rust-src
+          rustup override set nightly
+          cargo install cargo-careful
+
+      - name: Get target triple
+        run: |
+          echo "TARGET=$(rustc -vV | awk '/^host: / { print $2 }')" >>${GITHUB_ENV}
+
+      - name: Run test with address sanitizer
+        env:
+          RUSTFLAGS: -Z sanitizer=address
+          RUSTDOCFLAGS: -Z sanitizer=address
+          # Note: because we don't build GDAL with sanitizers, we need to turn off
+          # leak detection, otherwise it'll report memory leak false positives
+          ASAN_OPTIONS: verbose=1:atexit=1:detect_stack_use_after_return=1:strict_string_checks=1:detect_leaks=0
+        run: cargo test -Zbuild-std --all --target ${{ env.TARGET }}
+
+      - name: Run tests with memory sanitizer
+        env:
+          RUSTFLAGS: -Z sanitizer=memory
+          RUSTDOCFLAGS: -Z sanitizer=memory
+        run: cargo test -Zbuild-std --target ${{ env.TARGET }}
+
+      - name: Run tests with careful
+        run: cargo careful test --all -Zcareful-sanitizer


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

If I've configured this correctly, once `sanitizer.yml` is on the `master` branch, we should be able to manually initiate running of this workflow on PRs via the [`workflow_dispatch`](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) trigger.


Notes:

* Makes use of [`cargo-careful`](https://github.com/RalfJung/cargo-careful)
* Among other things, `cargo-careful` enables [`AddressSanitizer`](https://github.com/japaric/rust-san#addresssanitizer), whose options can be configured via `ASAN_OPTIONS`