### PR TITLE
Document panicking behavior in `Dataset::set_gcps`

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -154,6 +154,10 @@ impl Dataset {
     /// setting their coordinate system.
     ///
     /// See: [`GDALDataset::SetGCPs(int, const GDAL_GCP *, const OGRSpatialReference *)`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset7SetGCPsEiPK8GDAL_GCPPK19OGRSpatialReference)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `gcps` has more than [`libc::c_int::MAX`] elements.
     pub fn set_gcps(&self, gcps: Vec<Gcp>, spatial_ref: &SpatialRef) -> Result<()> {
         assert!(
             gcps.len() <= libc::c_int::MAX as usize,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

