### PR TITLE
Prepare for `0.15` release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         run: cargo build
       - name: Run tests
         run: cargo test
-      - name: Build
+      - name: Build (--all-features)
         run: cargo build --all-features
-      - name: Run tests
+      - name: Run tests (--all-features)
         run: cargo test --all-features
 
   ubuntu_lts:
@@ -103,7 +103,7 @@ jobs:
         run: cargo build
       - name: Run tests
         run: cargo test
-      - name: Build
+      - name: Build (--all-features)
         run: cargo build --all-features
-      - name: Run tests
+      - name: Run tests (--all-features)
         run: cargo test --all-features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased
+
+## 0.15
 - **Breaking**: `RasterBand::actual_block_size` now takes two `usize` offsets instead of `(isize, isize)`
 
  - <https://github.com/georust/gdal/pull/413>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gdal"
 description = "GDAL bindings for Rust"
 license = "MIT"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "Alex Morega <alex@grep.ro>",
     "Johannes Drönner <droenner@informatik.uni-marburg.de>",
@@ -21,7 +21,7 @@ array = ["ndarray"]
 thiserror = "1.0"
 libc = "0.2"
 geo-types = { version = "0.7.8" }
-gdal-sys = { path = "gdal-sys", version = "^0.8" }
+gdal-sys = { path = "gdal-sys", version = "^0.9" }
 ndarray = { version = "0.15", optional = true }
 chrono = { version = "0.4.23", default-features = false }
 bitflags = "2.2"

--- a/gdal-sys/Cargo.toml
+++ b/gdal-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gdal-sys"
 description = "Low level GDAL bindings for Rust"
 license = "MIT"
-version = "0.8.0"
+version = "0.9.0"
 repository = "https://github.com/georust/gdal"
 authors = ["Johannes Drönner <droenner@informatik.uni-marburg.de>"]
 categories = ["science::geo", "api-bindings"]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

