### PR TITLE
Added Send trait to vector structs

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -282,6 +282,8 @@ impl<'a> Default for LayerOptions<'a> {
     }
 }
 
+unsafe impl Send for LayerOptions<'_> {}
+
 // GDAL Docs state: The returned dataset should only be accessed by one thread at a time.
 // See: https://gdal.org/api/raster_c_api.html#_CPPv48GDALOpenPKc10GDALAccess
 // Additionally, VRT Datasets are not safe before GDAL 2.3.

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -594,6 +594,8 @@ impl SpatialRef {
     }
 }
 
+unsafe impl Send for SpatialRef {}
+
 #[derive(Debug, Clone)]
 /// Defines the bounding area of valid use for a [`SpatialRef`].
 ///

--- a/src/vector/defn.rs
+++ b/src/vector/defn.rs
@@ -61,6 +61,8 @@ impl Defn {
     }
 }
 
+unsafe impl Send for Defn {}
+
 pub struct FieldIterator<'a> {
     defn: &'a Defn,
     c_feature_defn: OGRFeatureDefnH,

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -668,6 +668,8 @@ impl<'a> Feature<'a> {
     }
 }
 
+unsafe impl Send for Feature<'_> {}
+
 pub struct FieldValueIterator<'a> {
     feature: &'a Feature<'a>,
     idx: i32,

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -381,6 +381,8 @@ impl Debug for GeometryRef<'_> {
     }
 }
 
+unsafe impl Send for GeometryRef<'_> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -137,6 +137,8 @@ impl<'a> Layer<'a> {
     }
 }
 
+unsafe impl Send for Layer<'_> {}
+
 /// Layer in a vector dataset
 ///
 /// ```


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I needed vector structs to be send for my use case, due to use in an async functions. These changes for good for my use case, since I'm wrapping everything in an `Arc<Mutex<`, but let me know if this might cause potential issues, or if something else is needed to make these changes safer.