### PR TITLE
Fix linting on clippy > 1.71

### DIFF
--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -215,7 +215,7 @@ impl Geometry {
         let geom = unsafe { self.get_unowned_geometry(index) };
         GeometryRef {
             geom,
-            _lifetime: PhantomData::default(),
+            _lifetime: PhantomData,
         }
     }
 

--- a/src/vsi.rs
+++ b/src/vsi.rs
@@ -81,7 +81,7 @@ impl<'d> MemFileRef<'d> {
     pub fn new(file_name: &Path) -> MemFileRef<'d> {
         Self {
             file_name: file_name.into(),
-            data_ref: PhantomData::default(),
+            data_ref: PhantomData,
         }
     }
 }


### PR DESCRIPTION

This fixes linting for clippy > 1.71 which introduced a new [default_constructed_unit_structs](https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs) (see [clippy's changelog](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md))

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

