### PR TITLE
Rewrote `spatial_ref::srs::tests::from_proj4_to_wkt`...

### DIFF
--- a/examples/version.rs
+++ b/examples/version.rs
@@ -1,0 +1,7 @@
+use gdal::version::VersionInfo;
+
+/// So you can do `cargo run --example version` for bug reports. :-)
+fn main() {
+    let report = VersionInfo::version_report();
+    println!("{report}");
+}

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -631,8 +631,11 @@ mod tests {
         "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs",
     )
     .unwrap();
-
-        let round_trip = SpatialRef::from_wkt(&spatial_ref.to_wkt().unwrap()).unwrap();
+        let wkt = spatial_ref.to_wkt().unwrap();
+        // Test we the DATUM description has expected tokens
+        assert!(wkt.contains("GRS") && wkt.contains("80"));
+        // Test parsing back in gets us functionally the same SRS
+        let round_trip = SpatialRef::from_wkt(&wkt).unwrap();
         assert_eq!(spatial_ref, round_trip);
     }
 

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -631,11 +631,9 @@ mod tests {
         "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs",
     )
     .unwrap();
-        // TODO: handle proj changes on lib level
-        #[cfg(not(major_ge_3))]
-        assert_eq!(spatial_ref.to_wkt().unwrap(), "PROJCS[\"unnamed\",GEOGCS[\"GRS 1980(IUGG, 1980)\",DATUM[\"unknown\",SPHEROID[\"GRS80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]],PROJECTION[\"Lambert_Azimuthal_Equal_Area\"],PARAMETER[\"latitude_of_center\",52],PARAMETER[\"longitude_of_center\",10],PARAMETER[\"false_easting\",4321000],PARAMETER[\"false_northing\",3210000],UNIT[\"Meter\",1]]");
-        #[cfg(major_ge_3)]
-        assert_eq!(spatial_ref.to_wkt().unwrap(), "PROJCS[\"unknown\",GEOGCS[\"unknown\",DATUM[\"Unknown based on GRS80 ellipsoid\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Lambert_Azimuthal_Equal_Area\"],PARAMETER[\"latitude_of_center\",52],PARAMETER[\"longitude_of_center\",10],PARAMETER[\"false_easting\",4321000],PARAMETER[\"false_northing\",3210000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]");
+
+        let round_trip = SpatialRef::from_wkt(&spatial_ref.to_wkt().unwrap()).unwrap();
+        assert_eq!(spatial_ref, round_trip);
     }
 
     #[test]


### PR DESCRIPTION
...to be less sensitive to Proj database changes.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Also added `examples/version.rs` to make it easy to report GDAL build info with bug reports.

Closes #441 