### PR TITLE
Rewrote `vector::ops::transformations::tests::test_simplify_preserve_topology`...

### DIFF
--- a/src/vector/ops/transformations.rs
+++ b/src/vector/ops/transformations.rs
@@ -249,13 +249,9 @@ mod tests {
 
     #[test]
     fn test_simplify_preserve_topology() -> Result<()> {
-        let donut = Geometry::from_wkt(
-            "POLYGON ((20 35,10 30,10 10,30 5,45 20,20 35),(30 20,20 15,20 25,30 20))",
-        )?;
-        let triangles = Geometry::from_wkt(
-            "POLYGON ((20 35,10 10,30 5,45 20,20 35),(30 20,20 15,20 25,30 20))",
-        )?;
-        assert_eq!(donut.simplify_preserve_topology(100.0)?, triangles);
+        let test = Geometry::from_wkt("LINESTRING(0 0,1 0,10 0)")?;
+        let expected = Geometry::from_wkt("LINESTRING (0 0,10 0)")?;
+        assert_eq!(test.simplify_preserve_topology(5.0)?, expected);
         Ok(())
     }
 


### PR DESCRIPTION
...to be less sensitive to GEOS changes.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---


This change replicates the test used in `OSGeo/gdal` for this feature rather than attempts a more challenging test:

https://github.com/OSGeo/gdal/blob/b33e3b318b6cf43d5ccfa35e1ad0e5e22313d09f/autotest/ogr/ogr_geos.py#L327


Closes #443 