### PR TITLE
Don't derive Clone, PartialEq and Eq for ExtendedDataType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,14 +2,19 @@
 
 ## Unreleased
 
- - Refactored `dataset.rs` to focus on core `Dataset` operations, moving ancillary types and operations to other files.
- - **Breaking**: Moved `LayerIterator`, `LayerOptions` and `Transaction` to `crate::vector`.
- - Accessors `MajorObject::gdal_object_ptr` and `Dataset::c_dataset()` are no longer marked as `unsafe` (it's not idiomatic Rust to do so).
-  
-   - <https://github.com/georust/gdal/pull/447> 
- 
- - Fixed build script error with development GDAL versions
+ - **Breaking**: `ExtendedDataType` no longer implements `Clone`, `PartialEq` and `Eq`
 
+   - <https://github.com/georust/gdal/pull/451>
+
+ - **Breaking**: Moved `LayerIterator`, `LayerOptions` and `Transaction` to `crate::vector`
+
+   - <https://github.com/georust/gdal/pull/447>
+
+ - Accessors `MajorObject::gdal_object_ptr` and `Dataset::c_dataset()` are no longer marked as `unsafe` (only using these is unsafe in idiomatic Rust)
+
+   - <https://github.com/georust/gdal/pull/447>
+
+ - Fixed build script error with development GDAL versions
 
   - <https://github.com/georust/gdal/pull/439>
 

--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -611,7 +611,7 @@ impl<'a> Dimension<'a> {
 }
 
 /// Wrapper for `GDALExtendedDataType`
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct ExtendedDataType {
     c_data_type: GDALExtendedDataTypeH,
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #449