### PR TITLE
Make SpatialRef::set_axis_mapping_strategy take self by mut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
+- **Breaking**: `SpatialRef::set_axis_mapping_strategy` now takes `&mut self`
+
+  - <https://github.com/georust/gdal/pull/461>
+
 - **Breaking**: `Dataset::raster_count` now returns an `usize` and `Dataset::rasterband` now takes `usize` instead of `isize`
 
   - <https://github.com/georust/gdal/pull/434>
 
- - **Breaking**: `CslStringListIterator` returns a `CslStringListEntry` instead of `(String, String)` in order to differentiate between `key=value` entries vs `flag` entries.
- - **Breaking**: `CslStringList::fetch_name_value` returns `Option<String>` instead of `Result<Option<String>>`, better reflecting the semantics of GDAL C API.
+- **Breaking**: `CslStringListIterator` returns a `CslStringListEntry` instead of `(String, String)` in order to differentiate between `key=value` entries vs `flag` entries.
+- **Breaking**: `CslStringList::fetch_name_value` returns `Option<String>` instead of `Result<Option<String>>`, better reflecting the semantics of GDAL C API.
  - Added `CslStringList::get_field`, `CslStringList::find_string`, `CslStringList::partial_find_string`, `CslStringList::find_string_case_sensitive`, `CslStringList::into_ptr`, `CslStringList::add_name_value`.
 
    - <https://github.com/georust/gdal/pull/455>

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -403,7 +403,7 @@ impl SpatialRef {
     }
 
     #[cfg(major_ge_3)]
-    pub fn set_axis_mapping_strategy(&self, strategy: gdal_sys::OSRAxisMappingStrategy::Type) {
+    pub fn set_axis_mapping_strategy(&mut self, strategy: gdal_sys::OSRAxisMappingStrategy::Type) {
         unsafe {
             gdal_sys::OSRSetAxisMappingStrategy(self.0, strategy);
         }
@@ -748,7 +748,7 @@ mod tests {
     #[cfg(major_ge_3)]
     #[test]
     fn axis_mapping_strategy() {
-        let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
+        let mut spatial_ref = SpatialRef::from_epsg(4326).unwrap();
         assert_eq!(
             spatial_ref.axis_mapping_strategy(),
             gdal_sys::OSRAxisMappingStrategy::OAMS_AUTHORITY_COMPLIANT

--- a/src/spatial_ref/transform.rs
+++ b/src/spatial_ref/transform.rs
@@ -272,8 +272,8 @@ mod tests {
 
     #[test]
     fn transform_coordinates() {
-        let spatial_ref1 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
-        let spatial_ref2 = SpatialRef::from_epsg(3035).unwrap();
+        let mut spatial_ref1 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
+        let mut spatial_ref2 = SpatialRef::from_epsg(3035).unwrap();
 
         // TODO: handle axis order in tests
         #[cfg(major_ge_3)]
@@ -306,11 +306,11 @@ mod tests {
             "POLYGON((23.43 37.58, 23.43 40.0, 25.29 40.0, 25.29 37.58, 23.43 37.58))",
         )
         .unwrap();
-        let spatial_ref1 = SpatialRef::from_proj4(
+        let mut spatial_ref1 = SpatialRef::from_proj4(
         "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs",
     )
     .unwrap();
-        let spatial_ref2 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
+        let mut spatial_ref2 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
 
         // TODO: handle axis order in tests
         #[cfg(major_ge_3)]
@@ -329,8 +329,8 @@ mod tests {
 
     #[test]
     fn failing_transformation() {
-        let wgs84 = SpatialRef::from_epsg(4326).unwrap();
-        let dhd_2 = SpatialRef::from_epsg(31462).unwrap();
+        let mut wgs84 = SpatialRef::from_epsg(4326).unwrap();
+        let mut dhd_2 = SpatialRef::from_epsg(31462).unwrap();
 
         // TODO: handle axis order in tests
         #[cfg(major_ge_3)]
@@ -350,8 +350,8 @@ mod tests {
         let r = trafo.transform_coords(&mut x, &mut y, &mut z);
         assert!(r.is_err());
 
-        let wgs84 = SpatialRef::from_epsg(4326).unwrap();
-        let webmercator = SpatialRef::from_epsg(3857).unwrap();
+        let mut wgs84 = SpatialRef::from_epsg(4326).unwrap();
+        let mut webmercator = SpatialRef::from_epsg(3857).unwrap();
 
         // TODO: handle axis order in tests
         #[cfg(major_ge_3)]

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -1468,7 +1468,7 @@ mod tests {
         assert_eq!(name_list, ok_names_types);
 
         let geom_field = layer.defn().geom_fields().next().unwrap();
-        let spatial_ref2 = SpatialRef::from_epsg(4326).unwrap();
+        let mut spatial_ref2 = SpatialRef::from_epsg(4326).unwrap();
         #[cfg(major_ge_3)]
         spatial_ref2.set_axis_mapping_strategy(0);
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Closes #460