### PR TITLE
Add histogram calculation for RasterBand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@
 
   - <https://github.com/georust/gdal/pull/439>
 
+- Added Histogram calculation
+
 ## 0.16
 
 - **Breaking**: `Dataset::close` now consumes `self`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,8 @@
 
 - Added Histogram calculation
 
+  - <https://github.com/georust/gdal/pull/468>
+
 ## 0.16
 
 - **Breaking**: `Dataset::close` now consumes `self`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,7 @@
 
   - <https://github.com/georust/gdal/pull/439>
 
-- Added Histogram calculation
+- Added histogram calculation
 
   - <https://github.com/georust/gdal/pull/468>
 

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -88,7 +88,7 @@ pub use mdarray::{
 };
 pub use rasterband::{
     Buffer, ByteBuffer, CmykEntry, ColorEntry, ColorInterpretation, ColorTable, GrayEntry,
-    HlsEntry, PaletteInterpretation, RasterBand, ResampleAlg, RgbaEntry, StatisticsAll,
+    Histogram, HlsEntry, PaletteInterpretation, RasterBand, ResampleAlg, RgbaEntry, StatisticsAll,
     StatisticsMinMax,
 };
 pub use rasterize::{rasterize, BurnSource, MergeAlgorithm, OptimizeMode, RasterizeOptions};

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -901,6 +901,10 @@ impl<'a> RasterBand<'a> {
         include_out_of_range: bool,
         is_approx_ok: bool,
     ) -> Result<Histogram> {
+        if n_buckets == 0 {
+            return Err(GdalError::BadArgument("n_buckets should be > 0".to_string()));
+        }
+
         let mut counts = vec![0; n_buckets];
 
         let rv = unsafe {

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -902,7 +902,9 @@ impl<'a> RasterBand<'a> {
         is_approx_ok: bool,
     ) -> Result<Histogram> {
         if n_buckets == 0 {
-            return Err(GdalError::BadArgument("n_buckets should be > 0".to_string()));
+            return Err(GdalError::BadArgument(
+                "n_buckets should be > 0".to_string(),
+            ));
         }
 
         let mut counts = vec![0; n_buckets];

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -752,6 +752,39 @@ fn test_raster_stats() {
 }
 
 #[test]
+fn test_raster_histogram() {
+    let fixture = TempFixture::fixture("tinymarble.tif");
+
+    let dataset = Dataset::open(&fixture).unwrap();
+    let rb = dataset.rasterband(1).unwrap();
+
+    let hist = rb.get_default_histogram(true).unwrap().unwrap();
+    let expected = &[
+        548, 104, 133, 127, 141, 125, 156, 129, 130, 117, 94, 94, 80, 81, 78, 63, 50, 66, 48, 48,
+        33, 38, 41, 35, 41, 39, 32, 40, 26, 27, 25, 24, 18, 25, 29, 27, 20, 34, 17, 24, 29, 11, 20,
+        21, 12, 19, 16, 16, 11, 10, 19, 5, 11, 10, 6, 9, 7, 12, 13, 6, 8, 7, 8, 14, 9, 14, 4, 8, 5,
+        12, 6, 10, 7, 9, 8, 6, 3, 7, 5, 8, 9, 5, 4, 8, 3, 9, 3, 6, 11, 7, 6, 3, 9, 9, 7, 6, 9, 10,
+        10, 4, 7, 2, 4, 7, 2, 12, 7, 10, 4, 6, 5, 2, 4, 5, 7, 3, 5, 7, 7, 14, 9, 12, 6, 6, 8, 5, 8,
+        3, 3, 5, 11, 4, 9, 7, 14, 7, 10, 11, 6, 6, 5, 4, 9, 6, 6, 9, 5, 12, 11, 9, 3, 8, 5, 6, 4,
+        2, 9, 7, 9, 9, 9, 6, 6, 8, 5, 9, 13, 4, 9, 4, 7, 13, 10, 5, 7, 8, 11, 12, 5, 17, 9, 11, 9,
+        8, 9, 5, 8, 9, 5, 6, 9, 11, 8, 7, 7, 6, 7, 8, 8, 8, 5, 6, 7, 5, 8, 5, 6, 8, 7, 4, 8, 6, 5,
+        11, 8, 8, 5, 4, 6, 4, 9, 7, 6, 6, 7, 7, 12, 6, 9, 17, 12, 20, 18, 17, 21, 24, 30, 29, 57,
+        72, 83, 21, 11, 9, 18, 7, 13, 10, 2, 4, 0, 1, 3, 4, 1, 1,
+    ];
+    assert_eq!(hist.histogram(), expected);
+
+    let hist = rb
+        .get_histogram(-0.5, 255.5, 128, true, true)
+        .unwrap()
+        .unwrap();
+    let expected_small = (0..expected.len())
+        .step_by(2)
+        .map(|i| expected[i] + expected[i + 1])
+        .collect::<Vec<_>>();
+    assert_eq!(hist.histogram(), &expected_small);
+}
+
+#[test]
 fn test_resample_str() {
     assert!(ResampleAlg::from_str("foobar").is_err());
 

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -758,6 +758,9 @@ fn test_raster_histogram() {
     let dataset = Dataset::open(&fixture).unwrap();
     let rb = dataset.rasterband(1).unwrap();
 
+    let hist = rb.default_histogram(false).unwrap();
+    assert!(hist.is_none());
+
     let hist = rb.default_histogram(true).unwrap().unwrap();
     let expected = &[
         548, 104, 133, 127, 141, 125, 156, 129, 130, 117, 94, 94, 80, 81, 78, 63, 50, 66, 48, 48,
@@ -773,7 +776,7 @@ fn test_raster_histogram() {
     ];
     assert_eq!(hist.counts(), expected);
 
-    let hist = rb.histogram(-0.5, 255.5, 128, true, true).unwrap().unwrap();
+    let hist = rb.histogram(-0.5, 255.5, 128, true, true).unwrap();
     let expected_small = (0..expected.len())
         .step_by(2)
         .map(|i| expected[i] + expected[i + 1])

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -758,7 +758,7 @@ fn test_raster_histogram() {
     let dataset = Dataset::open(&fixture).unwrap();
     let rb = dataset.rasterband(1).unwrap();
 
-    let hist = rb.get_default_histogram(true).unwrap().unwrap();
+    let hist = rb.default_histogram(true).unwrap().unwrap();
     let expected = &[
         548, 104, 133, 127, 141, 125, 156, 129, 130, 117, 94, 94, 80, 81, 78, 63, 50, 66, 48, 48,
         33, 38, 41, 35, 41, 39, 32, 40, 26, 27, 25, 24, 18, 25, 29, 27, 20, 34, 17, 24, 29, 11, 20,
@@ -771,17 +771,14 @@ fn test_raster_histogram() {
         11, 8, 8, 5, 4, 6, 4, 9, 7, 6, 6, 7, 7, 12, 6, 9, 17, 12, 20, 18, 17, 21, 24, 30, 29, 57,
         72, 83, 21, 11, 9, 18, 7, 13, 10, 2, 4, 0, 1, 3, 4, 1, 1,
     ];
-    assert_eq!(hist.histogram(), expected);
+    assert_eq!(hist.counts(), expected);
 
-    let hist = rb
-        .get_histogram(-0.5, 255.5, 128, true, true)
-        .unwrap()
-        .unwrap();
+    let hist = rb.histogram(-0.5, 255.5, 128, true, true).unwrap().unwrap();
     let expected_small = (0..expected.len())
         .step_by(2)
         .map(|i| expected[i] + expected[i + 1])
         .collect::<Vec<_>>();
-    assert_eq!(hist.histogram(), &expected_small);
+    assert_eq!(hist.counts(), &expected_small);
 }
 
 #[test]

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -782,6 +782,10 @@ fn test_raster_histogram() {
         .map(|i| expected[i] + expected[i + 1])
         .collect::<Vec<_>>();
     assert_eq!(hist.counts(), &expected_small);
+
+    // n_buckets = 0 is not allowed
+    let hist = rb.histogram(-0.5, 255.5, 0, true, true);
+    hist.expect_err("histogram with 0 buckets should panic");
 }
 
 #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR exposes 2 GDAL methods to calculate band histograms (default and user-defined).