### PR TITLE
_read_dir(): fix memory leak

### DIFF
--- a/src/vsi.rs
+++ b/src/vsi.rs
@@ -30,7 +30,9 @@ pub fn read_dir<P: AsRef<Path>>(path: P, recursive: bool) -> Result<Vec<PathBuf>
             data
         };
 
-        Ok(_pathbuf_array(data))
+        let ret = Ok(_pathbuf_array(data));
+        unsafe { gdal_sys::CSLDestroy(data) };
+        ret
     }
     _read_dir(path.as_ref(), recursive)
 }


### PR DESCRIPTION
Fixes leak reported by ``cargo valgrind test --lib``:
```
       Error leaked 200 B in 1 block
        Info at malloc
             at CPLMalloc
             at CPLCalloc
             at CPLStringList::EnsureAllocation(int)
             at CPLStringList::AddStringDirectly(char*)
             at unknown
             at unknown
             at gdal::vsi::_read_dir (vsi.rs:30)
             at gdal::vsi::read_dir (vsi.rs:18)
             at gdal::vsi::tests::test_vsi_read_dir (vsi.rs:314)
             at gdal::vsi::tests::test_vsi_read_dir::{{closure}} (vsi.rs:294)
             at core::ops::function::FnOnce::call_once (function.rs:250)
       Error leaked 219 B in 1 block
        Info at malloc
             at CPLMalloc
             at CPLCalloc
             at CPLStringList::EnsureAllocation(int)
             at CPLStringList::AddStringDirectly(char*)
             at VSIReadDirRecursive
             at gdal::vsi::_read_dir (vsi.rs:24)
             at gdal::vsi::read_dir (vsi.rs:18)
             at gdal::vsi::tests::test_vsi_read_dir (vsi.rs:325)
             at gdal::vsi::tests::test_vsi_read_dir::{{closure}} (vsi.rs:294)
             at core::ops::function::FnOnce::call_once (function.rs:250)
             at call_once<fn() -> core::result::Result<(), alloc::string::String>, ()> (function.rs:250)
             at test::__rust_begin_short_backtrace (lib.rs:626)
     Summary Leaked 419 B total
```

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

