### PR TITLE
Stop using deprecated OGR_G_Equal

### DIFF
--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -349,7 +349,7 @@ impl Debug for Geometry {
 
 impl PartialEq for Geometry {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { gdal_sys::OGR_G_Equal(self.c_geometry(), other.c_geometry()) != 0 }
+        unsafe { gdal_sys::OGR_G_Equals(self.c_geometry(), other.c_geometry()) != 0 }
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

