### PR TITLE
MDArray::read_as_string_array(): make it robust to null string pointer being returned by GDAL

### DIFF
--- a/src/raster/mdarray.rs
+++ b/src/raster/mdarray.rs
@@ -330,11 +330,15 @@ impl<'a> MDArray<'a> {
             let strings = string_pointers
                 .into_iter()
                 .map(|string_ptr| {
-                    let string = _string(string_ptr);
+                    if string_ptr == std::ptr::null() {
+                        String::new()
+                    } else {
+                        let string = _string(string_ptr);
 
-                    VSIFree(string_ptr as *mut c_void);
+                        VSIFree(string_ptr as *mut c_void);
 
-                    string
+                        string
+                    }
                 })
                 .collect();
 


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I can't really come with a unit test for that given what exists in the bindings, but this is definitely something that could happen for example with the MEM driver where a user could write an array with null strings in it.
