### PR TITLE
Check output type in `read_block`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- `RasterBand::read_block` now checks that the requested type matches the band type.
+
+   - <https://github.com/georust/gdal/pull/489>
+
 - Added `Geometry::difference`.
 
    - <https://github.com/georust/gdal/pull/487>

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -532,6 +532,12 @@ impl<'a> RasterBand<'a> {
     /// # Notes
     /// The Matrix shape is (rows, cols) and raster shape is (cols in x-axis, rows in y-axis).
     pub fn read_block<T: Copy + GdalType>(&self, block_index: (usize, usize)) -> Result<Array2<T>> {
+        if T::gdal_ordinal() != self.band_type() as u32 {
+            return Err(GdalError::BadArgument(
+                "result array type must match band data type".to_string(),
+            ));
+        }
+
         let size = self.block_size();
         let pixels = size.0 * size.1;
         let mut data: Vec<T> = Vec::with_capacity(pixels);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #485