### PR TITLE
Fixes for static pkg-config Windows build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Defers the gdal_i.lib missing message until after the pkg-config check and outputs pkg-config metadata in case of a static build.
+
+   - <https://github.com/georust/gdal/pull/492>
+
 - Added `RasterBand::write_block`.
 
    - <https://github.com/georust/gdal/pull/490>

--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -185,7 +185,9 @@ fn main() {
         println!("cargo:rustc-link-lib={link_type}={lib_name}");
         println!("cargo:rustc-link-search={}", lib_dir.to_str().unwrap());
 
-        need_metadata = false;
+        if !prefer_static {
+            need_metadata = false;
+        }
     }
 
     let mut include_paths = Vec::new();

--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -140,10 +140,6 @@ fn main() {
             }
         }
         if !found {
-            if cfg!(target_env = "msvc") {
-                panic!("windows-msvc requires gdal_i.lib to be present in either $GDAL_LIB_DIR or $GDAL_HOME\\lib.");
-            }
-
             // otherwise, look for a gdalxxx.dll in $GDAL_HOME/bin
             // works in windows-gnu
             if let Some(ref home_dir) = home_dir {
@@ -201,6 +197,10 @@ fn main() {
         .statik(prefer_static)
         .cargo_metadata(need_metadata)
         .probe("gdal");
+
+    if !found && cfg!(target_env = "msvc") && gdal_pkg_config.is_err() {
+        panic!("windows-msvc requires gdal_i.lib to be present in either $GDAL_LIB_DIR or $GDAL_HOME\\lib.");
+    }
 
     if let Ok(gdal) = &gdal_pkg_config {
         for dir in &gdal.include_paths {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Defers the `gdal_i.lib` missing message until after the pkg-config check and outputs pkg-config metadata in case of a static build.