### PR TITLE
Changed a number of APIs using `isize` when `usize` is semantically more appropriate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Breaking**: Changed a number of APIs using `isize` when `usize` is semantically more appropriate: `Driver::create.*`, `Rasterband::overview`, `Dataset::{layer|into_layer|layer_count}`.  
+
+  - <https://github.com/georust/gdal/pull/497>
+
 - Defers the gdal_i.lib missing message until after the pkg-config check and outputs pkg-config metadata in case of a static build.
 
    - <https://github.com/georust/gdal/pull/492>

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::sync::Once;
 
 use gdal_sys::{self, CPLErr, GDALDriverH, GDALMajorObjectH};
-use libc::c_int;
 
 use crate::cpl::CslStringList;
 use crate::dataset::Dataset;
@@ -206,17 +205,18 @@ impl Driver {
             options_c.set_name_value(option.key, option.value)?;
         }
 
-        let size_x = i32::try_from(size_x)?;
-        let size_y = i32::try_from(size_y)?;
+        let size_x = libc::c_int::try_from(size_x)?;
+        let size_y = libc::c_int::try_from(size_y)?;
+        let bands = libc::c_int::try_from(bands)?;
 
         let c_filename = _path_to_c_string(filename)?;
         let c_dataset = unsafe {
             gdal_sys::GDALCreate(
                 self.c_driver,
                 c_filename.as_ptr(),
-                size_x as c_int,
-                size_y as c_int,
-                bands as c_int,
+                size_x,
+                size_y,
+                bands,
                 data_type as u32,
                 options_c.as_ptr(),
             )

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -105,9 +105,9 @@ impl Driver {
     pub fn create<P: AsRef<Path>>(
         &self,
         filename: P,
-        size_x: isize,
-        size_y: isize,
-        bands: isize,
+        size_x: usize,
+        size_y: usize,
+        bands: usize,
     ) -> Result<Dataset> {
         self.create_with_band_type::<u8, _>(filename, size_x, size_y, bands)
     }
@@ -134,9 +134,9 @@ impl Driver {
     pub fn create_with_band_type<T: GdalType, P: AsRef<Path>>(
         &self,
         filename: P,
-        size_x: isize,
-        size_y: isize,
-        bands: isize,
+        size_x: usize,
+        size_y: usize,
+        bands: usize,
     ) -> Result<Dataset> {
         let options = [];
         self.create_with_band_type_with_options::<T, _>(filename, size_x, size_y, bands, &options)
@@ -176,9 +176,9 @@ impl Driver {
     pub fn create_with_band_type_with_options<T: GdalType, P: AsRef<Path>>(
         &self,
         filename: P,
-        size_x: isize,
-        size_y: isize,
-        bands: isize,
+        size_x: usize,
+        size_y: usize,
+        bands: usize,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
         Self::_create_with_band_type_with_options(
@@ -195,9 +195,9 @@ impl Driver {
     fn _create_with_band_type_with_options(
         &self,
         filename: &Path,
-        size_x: isize,
-        size_y: isize,
-        bands: isize,
+        size_x: usize,
+        size_y: usize,
+        bands: usize,
         data_type: GdalDataType,
         options: &[RasterCreationOption],
     ) -> Result<Dataset> {
@@ -205,6 +205,9 @@ impl Driver {
         for option in options {
             options_c.set_name_value(option.key, option.value)?;
         }
+
+        let size_x = i32::try_from(size_x)?;
+        let size_y = i32::try_from(size_y)?;
 
         let c_filename = _path_to_c_string(filename)?;
         let c_dataset = unsafe {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -85,6 +85,8 @@ pub enum GdalError {
     },
     #[error(transparent)]
     IntConversionError(#[from] TryFromIntError),
+    #[error("Buffer length {0} does not match raster size {1:?}")]
+    BufferSizeMismatch(usize, (usize, usize)),
 }
 
 /// A wrapper for [`CPLErr::Type`] that reflects it as an enum

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 //! GDAL Error Types
 
 use libc::c_int;
+use std::num::TryFromIntError;
 use thiserror::Error;
 
 use gdal_sys::{CPLErr, OGRErr, OGRFieldType, OGRwkbGeometryType};
@@ -82,6 +83,8 @@ pub enum GdalError {
         data_type: crate::raster::ExtendedDataTypeClass,
         method_name: &'static str,
     },
+    #[error(transparent)]
+    IntConversionError(#[from] TryFromIntError),
 }
 
 /// A wrapper for [`CPLErr::Type`] that reflects it as an enum

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -835,7 +835,9 @@ impl<'a> RasterBand<'a> {
         unsafe { Ok(gdal_sys::GDALGetOverviewCount(self.c_rasterband)) }
     }
 
-    pub fn overview(&self, overview_index: isize) -> Result<RasterBand<'a>> {
+    pub fn overview(&self, overview_index: usize) -> Result<RasterBand<'a>> {
+        let overview_index = i32::try_from(overview_index)?;
+
         unsafe {
             let c_band = self.c_rasterband;
             let overview = gdal_sys::GDALGetOverview(c_band, overview_index as libc::c_int);

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -836,11 +836,11 @@ impl<'a> RasterBand<'a> {
     }
 
     pub fn overview(&self, overview_index: usize) -> Result<RasterBand<'a>> {
-        let overview_index = i32::try_from(overview_index)?;
+        let overview_index = libc::c_int::try_from(overview_index)?;
 
         unsafe {
             let c_band = self.c_rasterband;
-            let overview = gdal_sys::GDALGetOverview(c_band, overview_index as libc::c_int);
+            let overview = gdal_sys::GDALGetOverview(c_band, overview_index);
             if overview.is_null() {
                 return Err(_last_null_pointer_err("GDALGetOverview"));
             }

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -32,9 +32,6 @@ impl Dataset {
     ///
     /// # Errors
     /// Returns an error if the band cannot be read, including in the case the index is 0.
-    ///
-    /// # Panics
-    /// Panics if the band index is greater than `c_int::MAX`.
     pub fn rasterband(&self, band_index: usize) -> Result<RasterBand> {
         let band_index = libc::c_int::try_from(band_index)?;
 
@@ -675,7 +672,6 @@ impl<'a> RasterBand<'a> {
     /// * `window` - the window position from top left
     /// * `window_size` - the window size (GDAL will interpolate data if window_size != Buffer.size)
     /// * `buffer` - the data to write into the window
-    ///
     pub fn write<T: GdalType + Copy>(
         &mut self,
         window: (isize, isize),
@@ -1012,9 +1008,6 @@ impl<'a> RasterBand<'a> {
     /// * `min` - Histogram lower bound
     /// * `max` - Histogram upper bound
     /// * `counts` - Histogram values for each bucket
-    ///
-    /// # Panics
-    /// Panics if the `counts.len()` is greater than `i32::MAX`.
     pub fn set_default_histogram(&self, min: f64, max: f64, counts: &mut [u64]) -> Result<()> {
         let n_buckets = libc::c_int::try_from(counts.len())?;
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -607,8 +607,8 @@ impl Dataset {
     /// Applies to vector datasets, and fetches by the given
     /// _0-based_ index.
     pub fn layer(&self, idx: usize) -> Result<Layer> {
-        let idx = i32::try_from(idx)?;
-        let c_layer = unsafe { gdal_sys::OGR_DS_GetLayer(self.c_dataset(), idx as c_int) };
+        let idx = libc::c_int::try_from(idx)?;
+        let c_layer = unsafe { gdal_sys::OGR_DS_GetLayer(self.c_dataset(), idx) };
         if c_layer.is_null() {
             return Err(_last_null_pointer_err("OGR_DS_GetLayer"));
         }
@@ -620,8 +620,8 @@ impl Dataset {
     /// Applies to vector datasets, and fetches by the given
     /// _0-based_ index.
     pub fn into_layer(self, idx: usize) -> Result<OwnedLayer> {
-        let idx = i32::try_from(idx)?;
-        let c_layer = unsafe { gdal_sys::OGR_DS_GetLayer(self.c_dataset(), idx as c_int) };
+        let idx = libc::c_int::try_from(idx)?;
+        let c_layer = unsafe { gdal_sys::OGR_DS_GetLayer(self.c_dataset(), idx) };
         if c_layer.is_null() {
             return Err(_last_null_pointer_err("OGR_DS_GetLayer"));
         }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Scope:

* `Driver::create.*`
* `Rasterband::overview`
* `Dataset::{layer|into_layer|layer_count}`


Closes #495 
