### PR TITLE
Add `DriverManager::get_drivers_for_filename` for the ability to auto detect compatible `Driver`s for writing data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `DriverManager::get_drivers_for_filename` for the ability to auto detect compatible `Driver`s for writing data.
+
 - Added `Feature::unset_field`
   - <https://github.com/georust/gdal/pull/503>
 


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #506

I have the tests at the end of `src/driver.rs`, let me know if I should remove it. 

I've only tested for getting the drivers here, but I tried using that function to see if the code I wrote that wrote GPKG files can write SHP now it works. Though some driver specific functions seem to make it not work if we're not careful (like `out_data.start_transaction()?` works for GPKG but not SHP).
