### PR TITLE
Add `DriverIterator` to iterate though the registered drivers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes
 
 ## Unreleased
+- Add `DriverIterator` format to iterate through drivers, as well as `DriverManager::all()` method that provides the iterator.
+
 - **Breaking**: `Feature::set_field_xxx` now take `&mut self`
   - <https://github.com/georust/gdal/pull/505>
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -452,24 +452,18 @@ impl DriverManager {
         }
     }
 
-    /// Get an `Iterator` for all the drivers.
+    /// Get an `Iterator` over for all the loaded drivers.
     ///
-    /// Warning: Adding or removing drivers while comsuming the
-    /// Iterator can have unexpected results.
+    /// Warning: Adding or removing drivers while consuming the
+    /// iterator is safe, but can produce less useful results.
     pub fn all() -> DriverIterator {
-        DriverIterator::new()
-    }
-}
-
-/// Iterator for the registered `Driver`s in `DriverManager`
-pub struct DriverIterator {
-    current: usize,
-}
-
-impl DriverIterator {
-    pub fn new() -> Self {
         DriverIterator { current: 0 }
     }
+}
+
+/// Iterator for the registered [`Driver`]s in [`DriverManager`]
+pub struct DriverIterator {
+    current: usize,
 }
 
 impl Iterator for DriverIterator {
@@ -504,7 +498,6 @@ mod tests {
 
     #[test]
     fn test_driver_iterator() {
-        assert_eq!(DriverManager::count(), DriverIterator::new().count());
         assert_eq!(DriverManager::count(), DriverManager::all().count());
 
         let drivers: HashSet<String> = DriverManager::all().map(|d| d.short_name()).collect();


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Fixes #512 

I've done the simplest implementation for the first commit:

```rust
pub struct DriverIterator {
    current: usize,
}

impl DriverIterator {
    pub fn new() -> Self {
        DriverIterator { current: 0 }
    }
}

impl Iterator for DriverIterator {
    type Item = Driver;

    fn next(&mut self) -> Option<Self::Item> {
        match DriverManager::get_driver(self.current) {
            Ok(d) => {
                self.current += 1;
                Some(d)
            }
            Err(_) => None,
        }
    }
}
```

Which seems too simple, so I'm thinking of adding the ability to filter by metadata.

Which would be something like this:

```rust

pub struct DriverIterator {
    current: usize,
    filters: Vec<String>,
}

impl DriverIterator {
    pub fn all() -> Self {
        DriverIterator {
            current: 0,
            filters: vec![],
        }
    }

    pub fn vectors() -> Self {
        DriverIterator {
            current: 0,
            filters: vec!["DCAP_VECTOR".into()],
        }
    }

    pub fn rasters() -> Self {
        DriverIterator {
            current: 0,
            filters: vec!["DCAP_RASTER".into()],
        }
    }

    pub fn with_metadata(metadata: Vec<String>) -> Self {
        DriverIterator {
            current: 0,
            filters: metadata,
        }
    }
}

impl Iterator for DriverIterator {
    type Item = Driver;

    fn next(&mut self) -> Option<Self::Item> {
        while let Ok(d) = DriverManager::get_driver(self.current) {
            self.current += 1;
            if self
                .filters
                .iter()
                .all(|f| d.metadata_item(f, "").is_some())
            {
                return Some(d);
            }
        }
        None
    }
}
```

If someone needs to filter by more complex conditions, they can use the filter directly in the iterator, but providing some options for vectors and rasters seems like a reasonable thing to do.

What do you think?

