### PR TITLE
Unified raster creation options over `CplStringList`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # Changes
 
 ## Unreleased
+
+- **Breaking** Removed `RasterCreationOption`and replaced usages of `[RasterCreationOption]` with `RasterCreationOptions`, a type alias for `CplStringList`.
+
+  - <https://github.com/georust/gdal/pull/519>
+
 - Add `DriverIterator` format to iterate through drivers, as well as `DriverManager::all()` method that provides the iterator.
   - <https://github.com/georust/gdal/pull/512>
 

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -5,7 +5,7 @@ use gdal_sys::{self, CPLErr, GDALDatasetH, GDALMajorObjectH};
 use crate::cpl::CslStringList;
 use crate::errors::*;
 use crate::options::DatasetOptions;
-use crate::raster::RasterCreationOption;
+use crate::raster::RasterCreationOptions;
 use crate::utils::{_last_cpl_err, _last_null_pointer_err, _path_to_c_string, _string};
 use crate::{
     gdal_major_object::MajorObject, spatial_ref::SpatialRef, Driver, GeoTransform, Metadata,
@@ -238,20 +238,15 @@ impl Dataset {
         &self,
         driver: &Driver,
         filename: P,
-        options: &[RasterCreationOption],
+        options: &RasterCreationOptions,
     ) -> Result<Dataset> {
         fn _create_copy(
             ds: &Dataset,
             driver: &Driver,
             filename: &Path,
-            options: &[RasterCreationOption],
+            options: &CslStringList,
         ) -> Result<Dataset> {
             let c_filename = _path_to_c_string(filename)?;
-
-            let mut c_options = CslStringList::new();
-            for option in options {
-                c_options.set_name_value(option.key, option.value)?;
-            }
 
             let c_dataset = unsafe {
                 gdal_sys::GDALCreateCopy(
@@ -259,7 +254,7 @@ impl Dataset {
                     c_filename.as_ptr(),
                     ds.c_dataset,
                     0,
-                    c_options.as_ptr(),
+                    options.as_ptr(),
                     None,
                     ptr::null_mut(),
                 )

--- a/src/raster/create_options.rs
+++ b/src/raster/create_options.rs
@@ -1,0 +1,7 @@
+use crate::cpl::CslStringList;
+
+/// Key/value pairs of options for passing driver-specific creation flags to
+/// [`Driver::create_with_band_type_with_options`](crate::Driver::create_with_band_type_with_options`).
+///
+/// See `papszOptions` in [GDAL's `Create(...)` API documentation](https://gdal.org/api/gdaldriver_cpp.html#_CPPv4N10GDALDriver6CreateEPKciii12GDALDataType12CSLConstList).
+pub type RasterCreationOptions = CslStringList;

--- a/src/raster/mod.rs
+++ b/src/raster/mod.rs
@@ -75,6 +75,7 @@
 //! ```
 
 pub use buffer::{Buffer, ByteBuffer};
+pub use create_options::RasterCreationOptions;
 #[cfg(all(major_ge_3, minor_ge_1))]
 pub use mdarray::{
     Attribute, Dimension, ExtendedDataType, ExtendedDataTypeClass, Group, MDArray, MdStatisticsAll,
@@ -88,6 +89,7 @@ pub use types::{AdjustedValue, GdalDataType, GdalType};
 pub use warp::reproject;
 
 mod buffer;
+mod create_options;
 #[cfg(all(major_ge_3, minor_ge_1))]
 mod mdarray;
 pub mod processing;
@@ -97,13 +99,3 @@ mod rasterize;
 mod tests;
 mod types;
 mod warp;
-
-/// Key/value pair for passing driver-specific creation options to
-/// [`Driver::create_with_band_type_wth_options`](crate::Driver::create_with_band_type_with_options`).
-///
-/// See `papszOptions` in [GDAL's `Create(...)` API documentation](https://gdal.org/api/gdaldriver_cpp.html#_CPPv4N10GDALDriver6CreateEPKciii12GDALDataType12CSLConstList).
-#[derive(Debug)]
-pub struct RasterCreationOption<'a> {
-    pub key: &'a str,
-    pub value: &'a str,
-}

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -578,23 +578,12 @@ impl<'a> RasterBand<'a> {
     /// ```rust, no_run
     /// # fn main() -> gdal::errors::Result<()> {
     /// use gdal::DriverManager;
-    /// use gdal::raster::{Buffer, RasterCreationOption};
+    /// use gdal::raster::{Buffer, RasterCreationOptions };
     ///
     /// let driver = DriverManager::get_driver_by_name("GTiff").unwrap();
-    /// let options = [
-    ///     RasterCreationOption {
-    ///         key: "TILED",
-    ///         value: "YES",
-    ///     },
-    ///     RasterCreationOption {
-    ///         key: "BLOCKXSIZE",
-    ///         value: "16",
-    ///     },
-    ///     RasterCreationOption {
-    ///         key: "BLOCKYSIZE",
-    ///         value: "16",
-    ///     },
-    /// ];
+    /// let options = RasterCreationOptions::from_iter([
+    ///    "TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"
+    /// ]);
     /// let dataset = driver
     ///     .create_with_band_type_with_options::<u16, _>(
     ///         "/vsimem/test_write_block.tif",
@@ -1434,7 +1423,7 @@ impl Debug for ColorEntry {
 ///
 /// // Create in-memory copy to mutate
 /// let mem_driver = DriverManager::get_driver_by_name("MEM")?;
-/// let ds = ds.create_copy(&mem_driver, "<mem>", &[])?;
+/// let ds = ds.create_copy(&mem_driver, "<mem>", &Default::default())?;
 /// let mut band = ds.rasterband(1)?;
 /// assert!(band.color_table().is_none());
 ///
@@ -1448,7 +1437,7 @@ impl Debug for ColorEntry {
 ///
 /// // Render a PNG
 /// let png_driver = DriverManager::get_driver_by_name("PNG")?;
-/// ds.create_copy(&png_driver, "/tmp/labels.png", &[])?;
+/// ds.create_copy(&png_driver, "/tmp/labels.png", &Default::default())?;
 ///
 /// # Ok(())
 /// # }

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -2,7 +2,7 @@ use crate::dataset::Dataset;
 use crate::metadata::Metadata;
 use crate::raster::rasterband::ResampleAlg;
 use crate::raster::{
-    ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, GdalDataType, RasterCreationOption,
+    ByteBuffer, ColorEntry, ColorInterpretation, ColorTable, GdalDataType, RasterCreationOptions,
     StatisticsAll, StatisticsMinMax,
 };
 use crate::test_utils::{fixture, TempFixture};
@@ -127,7 +127,9 @@ fn test_rename_remove_raster() {
 
     let driver = DriverManager::get_driver_by_name("GTiff").unwrap();
 
-    dataset.create_copy(&driver, mem_file_path_a, &[]).unwrap();
+    dataset
+        .create_copy(&driver, mem_file_path_a, &Default::default())
+        .unwrap();
 
     driver.rename(mem_file_path_b, mem_file_path_a).unwrap();
 
@@ -166,28 +168,13 @@ fn test_create_with_band_type() {
 #[test]
 fn test_create_with_band_type_with_options() {
     let driver = DriverManager::get_driver_by_name("GTiff").unwrap();
-    let options = [
-        RasterCreationOption {
-            key: "TILED",
-            value: "YES",
-        },
-        RasterCreationOption {
-            key: "BLOCKXSIZE",
-            value: "128",
-        },
-        RasterCreationOption {
-            key: "BLOCKYSIZE",
-            value: "64",
-        },
-        RasterCreationOption {
-            key: "COMPRESS",
-            value: "LZW",
-        },
-        RasterCreationOption {
-            key: "INTERLEAVE",
-            value: "BAND",
-        },
-    ];
+    let options = RasterCreationOptions::from_iter([
+        "TILED=YES",
+        "BLOCKXSIZE=128",
+        "BLOCKYSIZE=64",
+        "COMPRESS=LZW",
+        "INTERLEAVE=BAND",
+    ]);
 
     let tmp_filename = TempFixture::empty("test.tif");
     {
@@ -214,7 +201,9 @@ fn test_create_with_band_type_with_options() {
 fn test_create_copy() {
     let driver = DriverManager::get_driver_by_name("MEM").unwrap();
     let dataset = Dataset::open(fixture("tinymarble.tif")).unwrap();
-    let copy = dataset.create_copy(&driver, "", &[]).unwrap();
+    let copy = dataset
+        .create_copy(&driver, "", &Default::default())
+        .unwrap();
     assert_eq!(copy.raster_size(), (100, 50));
     assert_eq!(copy.raster_count(), 3);
 }
@@ -234,16 +223,7 @@ fn test_create_copy_with_options() {
         .create_copy(
             &DriverManager::get_driver_by_name("GTiff").unwrap(),
             mem_file_path,
-            &[
-                RasterCreationOption {
-                    key: "INTERLEAVE",
-                    value: "BAND",
-                },
-                RasterCreationOption {
-                    key: "COMPRESS",
-                    value: "LZW",
-                },
-            ],
+            &RasterCreationOptions::from_iter(["INTERLEAVE=BAND", "COMPRESS=LZW"]),
         )
         .unwrap();
 
@@ -391,20 +371,7 @@ fn test_read_block_data() {
 #[cfg(feature = "ndarray")]
 fn test_write_block() {
     let driver = DriverManager::get_driver_by_name("GTiff").unwrap();
-    let options = [
-        RasterCreationOption {
-            key: "TILED",
-            value: "YES",
-        },
-        RasterCreationOption {
-            key: "BLOCKXSIZE",
-            value: "16",
-        },
-        RasterCreationOption {
-            key: "BLOCKYSIZE",
-            value: "16",
-        },
-    ];
+    let options = RasterCreationOptions::from_iter(["TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"]);
     let dataset = driver
         .create_with_band_type_with_options::<u16, _>(
             "/vsimem/test_write_block.tif",
@@ -724,7 +691,7 @@ fn test_create_color_table() {
 
         // Create a new file to put color table in
         let dataset = dataset
-            .create_copy(&dataset.driver(), &outfile, &[])
+            .create_copy(&dataset.driver(), &outfile, &Default::default())
             .unwrap();
         dataset
             .rasterband(1)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This:

```rust
let options = [
    RasterCreationOption {
        key: "TILED",
        value: "YES",
    },
    RasterCreationOption {
        key: "BLOCKXSIZE",
        value: "16",
    },
    RasterCreationOption {
        key: "BLOCKYSIZE",
        value: "16",
    },
];

```

is now this:

```rust
let options = RasterCreationOptions::from_iter([
   "TILED=YES", "BLOCKXSIZE=16", "BLOCKYSIZE=16"
]);
```