### PR TITLE
build: no bindings: make error more explicit

### DIFF
--- a/gdal-sys/build.rs
+++ b/gdal-sys/build.rs
@@ -247,7 +247,7 @@ fn main() {
                 version.major, version.minor
             ));
             if !binding_path.exists() {
-                panic!("No pre-built bindings available for GDAL version {}.{}. Use `--features bindgen` to generate your own bindings.", version.major, version.minor);
+                panic!("No pre-built bindings available for GDAL version {}.{}. Enable the `bindgen` feature of the `gdal` or `gdal-sys` crate to generate them during build.", version.major, version.minor);
             }
 
             std::fs::copy(&binding_path, &out_path)


### PR DESCRIPTION
Hi,

The panic that arises when there are no pre-build bindings available is not that explicit and may confuse some users into thinking there's something wrong with GDAL.

Thanks!

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

