### PR TITLE
Add `Rasterband::fill`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added `Rasterband::fill`
+  - <https://github.com/georust/gdal/pull/528>
+
 - Added `Dataset::rasterbands`.
   - <https://github.com/georust/gdal/pull/523>
 

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -815,6 +815,28 @@ impl<'a> RasterBand<'a> {
             Ok(())
         }
     }
+
+    /// Fill this band with a constant value.
+    ///
+    /// If `imaginary_value` is `None`, the imaginary component will be set to 0.
+    ///
+    /// # Notes
+    /// See also:
+    /// [`GDALFillRaster`](https://gdal.org/api/gdalrasterband_cpp.html#classGDALRasterBand_1a55bf20527df638dc48bf25e2ff26f353)
+    pub fn fill(&mut self, real_value: f64, imaginary_value: Option<f64>) -> Result<()> {
+        let rv = unsafe {
+            gdal_sys::GDALFillRaster(
+                self.c_rasterband,
+                real_value,
+                imaginary_value.unwrap_or(0.0),
+            )
+        };
+        if rv != CPLErr::CE_None {
+            return Err(_last_cpl_err(rv));
+        }
+        Ok(())
+    }
+
     /// Returns the color interpretation of this band.
     pub fn color_interpretation(&self) -> ColorInterpretation {
         let interp_index = unsafe { gdal_sys::GDALGetRasterColorInterpretation(self.c_rasterband) };

--- a/src/raster/tests.rs
+++ b/src/raster/tests.rs
@@ -484,6 +484,18 @@ fn test_set_no_data_value() {
 }
 
 #[test]
+fn test_fill() {
+    let driver = DriverManager::get_driver_by_name("MEM").unwrap();
+    let dataset = driver.create("", 5, 5, 1).unwrap();
+    let mut rasterband = dataset.rasterband(1).unwrap();
+    assert!(rasterband.fill(5.4, None).is_ok());
+    let contents = rasterband
+        .read_as::<u8>((0, 0), (5, 5), (5, 5), None)
+        .unwrap();
+    assert!(contents.data().iter().all(|&v| v == 5));
+}
+
+#[test]
 fn test_get_scale() {
     let dataset = Dataset::open(fixture("offset_scaled_tinymarble.tif")).unwrap();
     let rasterband = dataset.rasterband(1).unwrap();


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This PR adds safe bindings for https://docs.rs/gdal-sys/latest/gdal_sys/fn.GDALFillRaster.html (https://gdal.org/api/gdalrasterband_cpp.html#classGDALRasterBand_1a55bf20527df638dc48bf25e2ff26f353)
The C++ API has a default value for the `dfImaginaryValue` param which is missing from the C API, so I reintroduced via an `Option`+`.unwrap_or`. Let me know if this isn't acceptable.
I also haven't tested that parameter, as I'm unsure how to read it back.