### PR TITLE
Catch potential null pointers returned by `Dataset::spatial_ref`

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -221,7 +221,17 @@ impl Dataset {
     #[cfg(major_ge_3)]
     /// Get the spatial reference system for this dataset.
     pub fn spatial_ref(&self) -> Result<SpatialRef> {
-        unsafe { SpatialRef::from_c_obj(gdal_sys::GDALGetSpatialRef(self.c_dataset)) }
+        unsafe {
+            let spatial_ref = gdal_sys::GDALGetSpatialRef(self.c_dataset);
+            if spatial_ref.is_null() {
+                Err(GdalError::NullPointer {
+                    method_name: "GDALGetSpatialRef",
+                    msg: "Unable to get a spatial reference".to_string(),
+                })
+            } else {
+                SpatialRef::from_c_obj(spatial_ref)
+            }
+        }
     }
 
     #[cfg(major_ge_3)]

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -51,6 +51,7 @@ impl SpatialRef {
     /// # Safety
     /// The handle passed to this function must be valid.
     pub unsafe fn from_c_obj(c_obj: gdal_sys::OGRSpatialReferenceH) -> Result<SpatialRef> {
+        assert!(!c_obj.is_null(), "Expected a pointer that is not null");
         let mut_c_obj = gdal_sys::OSRClone(c_obj);
         if mut_c_obj.is_null() {
             Err(_last_null_pointer_err("OSRClone"))


### PR DESCRIPTION
This otherwise hits an assertion in gdal debug builds for the OSRClone method

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

See https://github.com/OSGeo/gdal/blob/master/ogr/ogrspatialreference.cpp#L1406 for the relevant assertion in gdal
