### PR TITLE
return empty slice when there are no gcps

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -144,6 +144,10 @@ impl Dataset {
     /// See: [`GDALDataset::GetGCPs`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset7GetGCPsEv)
     pub fn gcps(&self) -> &[GcpRef] {
         let len = unsafe { gdal_sys::GDALGetGCPCount(self.c_dataset()) };
+        if len == 0 {
+            return &[];
+        }
+
         let data = unsafe { gdal_sys::GDALGetGCPs(self.c_dataset()) };
         unsafe { std::slice::from_raw_parts(data as *const GcpRef, len as usize) }
     }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Noticed this when upgrading to latest rust/running tests

```
--- STDOUT:              mio-gdal metadata::test::valid_nitf ---

running 1 test

--- STDERR:              mio-gdal metadata::test::valid_nitf ---
thread 'metadata::test::valid_nitf' panicked at library/core/src/panicking.rs:156:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:110:18
   2: core::panicking::panic_nounwind_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:123:9
   3: core::panicking::panic_nounwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:156:5
   4: core::slice::raw::from_raw_parts::precondition_check
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/intrinsics.rs:2799:21
   5: core::slice::raw::from_raw_parts
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/slice/raw.rs:98:9
   6: gdal::gcp::<impl gdal::dataset::Dataset>::gcp
```

I _think_ when there are no GCPs the resulting pointer `data` ends up as null, and this then panics even though `len` is correspondingly `0`