### PR TITLE
upgrade ndarray to 0.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Add a `bundled` feature for `gdal-sys` that allows to build and statically link a minimal bundled version of gdal during `cargo build`
 - Add methods ``alternative_name``, ``is_nullable``, ``is_unique``, ``default_value`` to ``Field``.
 - Add a `geometry_type` method to Layer.defn
+- Upgraded `ndarray` dependency to 0.16.
 
 ## 0.17.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 geo-types = { version = "0.7.11" }
 gdal-sys = { path = "gdal-sys", version = "0.10" }
 gdal-src = { path = "gdal-src", optional = true, default-features = false }
-ndarray = { version = "0.15", optional = true }
+ndarray = { version = "0.16", optional = true }
 chrono = { version = "0.4.26", default-features = false }
 bitflags = "2.4"
 once_cell = "1.18"


### PR DESCRIPTION
This PR upgrades the ndarray dependency from 0.15 to 0.16


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

