### PR TITLE
Add an explicit include to gdal-src Cargo.toml

### DIFF
--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -3,8 +3,21 @@ name = "gdal-src"
 version = "0.1.0"
 edition = "2021"
 links = "gdal_src"
+description ="Build script for compiling GDAL from source."
+license-file = "source/LICENSE.TXT"
+repository = "https://github.com/georust/gdal/"
+include = [
+    "/src/lib.rs",
+    "/build.rs",
+    "/Cargo.toml",
+    "/source/**/*.cpp",
+    "/source/**/*.h",
+    "/source/**/CMakeLists.txt",
+    "/source/LICENSE.TXT",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 link-cplusplus = "1.0"


### PR DESCRIPTION
This commit adds an explicit include to the `Cargo.toml` file of gdal-src to minimize the amount of code uploaded to crates.io. This reduces the uncompressed package size from >100MB to ~50MB. This is still larger than what's allowed by crates.io by default, but I know that it is possible to get an exception from these default limits by just asking with a good reason. Source code from an existing established open source project counts as good reason, so that's just something that needs to be done before publishing the first version.

The last time I had this problem the workflow was as follows:

1. Publish an empty version
2. Ask the crates.io team to bump the limit, e.g. via zulip
3. Publish the real code.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

