### PR TITLE
Take the field index, not name, in the feature getters and setters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   - Include OS-specific versions of the pre-built bindings ([#574](https://github.com/georust/gdal/pull/574))
   - Upgrade `ndarray` dependency to 0.16 ([#569](https://github.com/georust/gdal/pull/569))
   - Upgrade `thiserror` dependency to 2.0 ([#586](https://github.com/georust/gdal/pull/586))
+  - Update `Feature::field`, `Feature::set_field`, `Feature::set_field_string`, `Feature::set_field_string_list`, `Feature::set_field_double`, `Feature::set_field_double_list`, `Feature::set_field_integer`, `Feature::set_field_integer_list`, `Feature::set_field_integer64`, `Feature::set_field_integer64_list`, `Feature::set_field_datetime`, `Feature::set_field_null`, `Feature::unset_field` to take a field index, not a name ([#581](https://github.com/georust/gdal/pull/581))
+  - Drop `Feature::field_as_integer_by_name`, `Feature::field_as_integer64_by_name`, `Feature::field_as_double_by_name`, `Feature::field_as_string_by_name`, `Feature::field_as_datetime_by_name` ([#581](https://github.com/georust/gdal/pull/581))
+  - Update `Feature::field_count` to return `usize` instead of `i32` ([#581](https://github.com/georust/gdal/pull/581))
+  - Update `Feature::field_as_integer`, `Feature::field_as_integer64`, `Feature::field_as_double`, `Feature::field_as_string`, `Feature::field_as_datetime` to take the field index as `usize` instead of `i32` ([#581](https://github.com/georust/gdal/pull/581))
+  - Drop `LayerAccess::create_feature_fields` ([#581](https://github.com/georust/gdal/pull/581))
 
 ### Added
 
@@ -17,6 +22,7 @@
   - Add pre-built bindings for GDAL 3.10 ([#573](https://github.com/georust/gdal/pull/573))
   - Add methods `alternative_name`, `is_nullable`, `is_unique`, `default_value` to `Field` ([#561](https://github.com/georust/gdal/pull/561))
   - Add `Defn::geometry_type` ([#562](https://github.com/georust/gdal/pull/562))
+  - Add `Defn::field_index` and `Feature::field_index` ([#581](https://github.com/georust/gdal/pull/581))
 
 ### Fixed
 

--- a/examples/read_write_ogr.rs
+++ b/examples/read_write_ogr.rs
@@ -52,9 +52,9 @@ fn run() -> Result<()> {
         }
 
         // copy each field value of the feature:
-        for fd in &fields_defn {
-            if let Some(value) = feature_a.field(&fd.0)? {
-                ft.set_field(&fd.0, &value)?;
+        for idx in 0..fields_defn.len() {
+            if let Some(value) = feature_a.field(idx)? {
+                ft.set_field(idx, &value)?;
             }
         }
         // Add the feature to the layer:

--- a/examples/read_write_ogr_datetime.rs
+++ b/examples/read_write_ogr_datetime.rs
@@ -35,10 +35,10 @@ fn run() -> gdal::errors::Result<()> {
             ft.set_geometry(geom.clone())?;
         }
         // copy each field value of the feature:
-        for field in defn.fields() {
+        for (idx, field) in defn.fields().enumerate() {
             ft.set_field(
-                &field.name(),
-                &match feature_a.field(field.name())?.unwrap() {
+                idx,
+                &match feature_a.field(idx)?.unwrap() {
                     // add one day to dates
                     FieldValue::DateValue(value) => {
                         println!("{} = {}", field.name(), value);

--- a/examples/write_ogr.rs
+++ b/examples/write_ogr.rs
@@ -1,10 +1,9 @@
 use gdal::errors::Result;
-use gdal::vector::{Defn, Feature, FieldDefn, FieldValue, Geometry, LayerAccess, OGRFieldType};
+use gdal::vector::{Defn, Feature, FieldDefn, Geometry, OGRFieldType};
 use gdal::DriverManager;
 use std::fs;
 
-/// Example 1, the detailed way:
-fn example_1() -> Result<()> {
+fn main() -> Result<()> {
     let path = std::env::temp_dir().join("output1.geojson");
     let _ = fs::remove_file(&path);
     let drv = DriverManager::get_driver_by_name("GeoJSON")?;
@@ -21,81 +20,32 @@ fn example_1() -> Result<()> {
 
     let defn = Defn::from_layer(&lyr);
 
+    let name_idx = defn.field_index("Name")?;
+    let value_idx = defn.field_index("Value")?;
+
     // 1st feature:
     let mut ft = Feature::new(&defn)?;
     ft.set_geometry(Geometry::from_wkt("POINT (45.21 21.76)")?)?;
-    ft.set_field_string("Name", "Feature 1")?;
-    ft.set_field_double("Value", 45.78)?;
+    ft.set_field_string(name_idx, "Feature 1")?;
+    ft.set_field_double(value_idx, 45.78)?;
     ft.create(&lyr)?;
 
     // 2nd feature:
     let mut ft = Feature::new(&defn)?;
-    ft.set_field_double("Value", 0.789)?;
+    ft.set_field_double(value_idx, 0.789)?;
     ft.set_geometry(Geometry::from_wkt("POINT (46.50 22.50)")?)?;
-    ft.set_field_string("Name", "Feature 2")?;
+    ft.set_field_string(name_idx, "Feature 2")?;
     ft.create(&lyr)?;
 
     // Feature triggering an error due to a wrong field name:
     let mut ft = Feature::new(&defn)?;
     ft.set_geometry(Geometry::from_wkt("POINT (46.50 22.50)")?)?;
-    ft.set_field_string("Name", "Feature 2")?;
-    match ft.set_field_double("Values", 0.789) {
+    ft.set_field_string(name_idx, "Feature 2")?;
+    match ft.set_field_double(value_idx, 0.789) {
         Ok(v) => v,
         Err(err) => println!("{err}"),
     };
     ft.create(&lyr)?;
 
     Ok(())
-}
-
-/// Example 2, same output, shortened way:
-fn example_2() -> Result<()> {
-    let path = std::env::temp_dir().join("output2.geojson");
-    let _ = fs::remove_file(&path);
-    let driver = DriverManager::get_driver_by_name("GeoJSON")?;
-    let mut ds = driver.create_vector_only(path.to_str().unwrap())?;
-    let mut layer = ds.create_layer(Default::default())?;
-
-    layer.create_defn_fields(&[
-        ("Name", OGRFieldType::OFTString),
-        ("Value", OGRFieldType::OFTReal),
-    ])?;
-
-    layer.create_feature_fields(
-        Geometry::from_wkt("POINT (45.21 21.76)")?,
-        &["Name", "Value"],
-        &[
-            FieldValue::StringValue("Feature 1".to_string()),
-            FieldValue::RealValue(45.78),
-        ],
-    )?;
-
-    layer.create_feature_fields(
-        Geometry::from_wkt("POINT (46.50 22.50)")?,
-        &["Name", "Value"],
-        &[
-            FieldValue::StringValue("Feature 2".to_string()),
-            FieldValue::RealValue(0.789),
-        ],
-    )?;
-
-    // Feature creation triggering an error due to a wrong field name:
-    match layer.create_feature_fields(
-        Geometry::from_wkt("POINT (46.50 22.50)")?,
-        &["Abcd", "Value"],
-        &[
-            FieldValue::StringValue("Feature 2".to_string()),
-            FieldValue::RealValue(0.789),
-        ],
-    ) {
-        Ok(v) => v,
-        Err(err) => println!("{err}"),
-    };
-
-    Ok(())
-}
-
-fn main() {
-    example_1().unwrap();
-    example_2().unwrap();
 }

--- a/src/vector/feature.rs
+++ b/src/vector/feature.rs
@@ -72,88 +72,80 @@ impl<'a> Feature<'a> {
         }
     }
 
-    /// Get the value of a named field. If the field exists, it returns a [`FieldValue`] wrapper,
-    /// that you need to unpack to a base type (string, float, etc).
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// If the field has an unsupported type, returns a [`GdalError::UnhandledFieldType`].
-    ///
-    /// If the field is null, returns `None`.
-    pub fn field<S: AsRef<str>>(&self, name: S) -> Result<Option<FieldValue>> {
-        let idx = self.field_idx_from_name(name)?;
-        self.field_from_id(idx)
-    }
-
-    /// Get the value of a named field. If the field exists, it returns a [`FieldValue`] wrapper,
+    /// Get the value of a field. If the field exists, it returns a [`FieldValue`] wrapper,
     /// that you need to unpack to a base type (string, float, etc).
     ///
     /// If the field has an unhandled type, returns a [`GdalError::UnhandledFieldType`].
     ///
     /// If the field is null, returns `None`.
-    fn field_from_id(&self, field_id: i32) -> Result<Option<FieldValue>> {
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_id) } != 0 {
+    pub fn field(&self, field_idx: usize) -> Result<Option<FieldValue>> {
+        let field_idx = field_idx.try_into()?;
+
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
             return Ok(None);
         }
 
-        let field_defn = unsafe { gdal_sys::OGR_F_GetFieldDefnRef(self.c_feature, field_id) };
+        let field_defn = unsafe { gdal_sys::OGR_F_GetFieldDefnRef(self.c_feature, field_idx) };
         let field_type = unsafe { gdal_sys::OGR_Fld_GetType(field_defn) };
         match field_type {
             OGRFieldType::OFTString => {
-                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsString(self.c_feature, field_id) };
+                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsString(self.c_feature, field_idx) };
                 Ok(Some(FieldValue::StringValue(_string(rv))))
             }
             OGRFieldType::OFTStringList => {
                 let rv = unsafe {
-                    let ptr = gdal_sys::OGR_F_GetFieldAsStringList(self.c_feature, field_id);
+                    let ptr = gdal_sys::OGR_F_GetFieldAsStringList(self.c_feature, field_idx);
                     _string_array(ptr)
                 };
                 Ok(Some(FieldValue::StringListValue(rv)))
             }
             OGRFieldType::OFTReal => {
-                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsDouble(self.c_feature, field_id) };
+                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsDouble(self.c_feature, field_idx) };
                 Ok(Some(FieldValue::RealValue(rv)))
             }
             OGRFieldType::OFTRealList => {
                 let rv = unsafe {
                     let mut len: i32 = 0;
                     let ptr =
-                        gdal_sys::OGR_F_GetFieldAsDoubleList(self.c_feature, field_id, &mut len);
+                        gdal_sys::OGR_F_GetFieldAsDoubleList(self.c_feature, field_idx, &mut len);
                     slice::from_raw_parts(ptr, len as usize).to_vec()
                 };
                 Ok(Some(FieldValue::RealListValue(rv)))
             }
             OGRFieldType::OFTInteger => {
-                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsInteger(self.c_feature, field_id) };
+                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsInteger(self.c_feature, field_idx) };
                 Ok(Some(FieldValue::IntegerValue(rv)))
             }
             OGRFieldType::OFTIntegerList => {
                 let rv = unsafe {
                     let mut len: i32 = 0;
                     let ptr =
-                        gdal_sys::OGR_F_GetFieldAsIntegerList(self.c_feature, field_id, &mut len);
+                        gdal_sys::OGR_F_GetFieldAsIntegerList(self.c_feature, field_idx, &mut len);
                     slice::from_raw_parts(ptr, len as usize).to_vec()
                 };
                 Ok(Some(FieldValue::IntegerListValue(rv)))
             }
             OGRFieldType::OFTInteger64 => {
-                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsInteger64(self.c_feature, field_id) };
+                let rv = unsafe { gdal_sys::OGR_F_GetFieldAsInteger64(self.c_feature, field_idx) };
                 Ok(Some(FieldValue::Integer64Value(rv)))
             }
             OGRFieldType::OFTInteger64List => {
                 let rv = unsafe {
                     let mut len: i32 = 0;
-                    let ptr =
-                        gdal_sys::OGR_F_GetFieldAsInteger64List(self.c_feature, field_id, &mut len);
+                    let ptr = gdal_sys::OGR_F_GetFieldAsInteger64List(
+                        self.c_feature,
+                        field_idx,
+                        &mut len,
+                    );
                     slice::from_raw_parts(ptr, len as usize).to_vec()
                 };
                 Ok(Some(FieldValue::Integer64ListValue(rv)))
             }
             OGRFieldType::OFTDateTime => Ok(Some(FieldValue::DateTimeValue(
-                self._field_as_datetime(field_id)?,
+                self._field_as_datetime(field_idx)?,
             ))),
             OGRFieldType::OFTDate => Ok(Some(FieldValue::DateValue(
-                self._field_as_datetime(field_id)?.date_naive(),
+                self._field_as_datetime(field_idx)?.date_naive(),
             ))),
             _ => Err(GdalError::UnhandledFieldType {
                 field_type,
@@ -162,22 +154,23 @@ impl<'a> Feature<'a> {
         }
     }
 
-    /// Get the index of the named field.
+    /// Get the index of a field.
     ///
     /// If the field is missing, returns [`GdalError::InvalidFieldName`].
     ///
-    fn field_idx_from_name<S: AsRef<str>>(&self, field_name: S) -> Result<i32> {
+    pub fn field_index<S: AsRef<str>>(&self, field_name: S) -> Result<usize> {
         let c_str_field_name = CString::new(field_name.as_ref())?;
-        let field_id =
-            unsafe { gdal_sys::OGR_F_GetFieldIndex(self.c_feature, c_str_field_name.as_ptr()) };
-        if field_id == -1 {
+        let field_idx =
+            unsafe { gdal_sys::OGR_F_GetFieldIndex(self.c_feature(), c_str_field_name.as_ptr()) };
+        if field_idx == -1 {
             return Err(GdalError::InvalidFieldName {
                 field_name: field_name.as_ref().to_string(),
                 method_name: "OGR_F_GetFieldIndex",
             });
         }
 
-        Ok(field_id)
+        let field_index = field_idx.try_into()?;
+        Ok(field_index)
     }
 
     /// Get the value of the specified field as a [`i32`].
@@ -187,57 +180,20 @@ impl<'a> Feature<'a> {
     /// Returns `Ok(None)` if the field is null.
     /// Returns `Ok(Some(0))` on other kinds of errors.
     ///
-    pub fn field_as_integer(&self, field_idx: i32) -> Result<Option<i32>> {
+    pub fn field_as_integer(&self, field_idx: usize) -> Result<Option<i32>> {
         if field_idx >= self.field_count() {
             return Err(GdalError::InvalidFieldIndex {
-                index: field_idx as usize,
+                index: field_idx,
                 method_name: "field_as_integer",
             });
         }
 
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
+        let idx = field_idx.try_into()?;
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, idx) } != 0 {
             return Ok(None);
         }
 
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger(self.c_feature, field_idx) };
-
-        Ok(Some(value))
-    }
-
-    /// Get the value of the specified field as a [`i32`].
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// Returns `Ok(None)` if the field is null.
-    /// Returns `Ok(Some(0))` on other kinds of errors.
-    ///
-    pub fn field_as_integer_by_name(&self, field_name: &str) -> Result<Option<i32>> {
-        let field_idx = self.field_idx_from_name(field_name)?;
-
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
-            return Ok(None);
-        }
-
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger(self.c_feature, field_idx) };
-
-        Ok(Some(value))
-    }
-
-    /// Get the value of the specified field as a [`i64`].
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// Returns `Ok(None)` if the field is null.
-    /// Returns `Ok(Some(0))` on other kinds of errors.
-    ///
-    pub fn field_as_integer64_by_name(&self, field_name: &str) -> Result<Option<i64>> {
-        let field_idx = self.field_idx_from_name(field_name)?;
-
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
-            return Ok(None);
-        }
-
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger64(self.c_feature, field_idx) };
+        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger(self.c_feature, idx) };
 
         Ok(Some(value))
     }
@@ -249,38 +205,20 @@ impl<'a> Feature<'a> {
     /// Returns `Ok(None)` if the field is null.
     /// Returns `Ok(Some(0))` on other kinds of errors.
     ///
-    pub fn field_as_integer64(&self, field_idx: i32) -> Result<Option<i64>> {
+    pub fn field_as_integer64(&self, field_idx: usize) -> Result<Option<i64>> {
         if field_idx >= self.field_count() {
             return Err(GdalError::InvalidFieldIndex {
-                index: field_idx as usize,
+                index: field_idx,
                 method_name: "field_as_integer64",
             });
         }
 
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
+        let idx = field_idx.try_into()?;
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, idx) } != 0 {
             return Ok(None);
         }
 
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger64(self.c_feature, field_idx) };
-
-        Ok(Some(value))
-    }
-
-    /// Get the value of the specified field as a [`f64`].
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// Returns `Ok(None)` if the field is null.
-    /// Returns `Ok(Some(0.))` on other kinds of errors.
-    ///
-    pub fn field_as_double_by_name(&self, field_name: &str) -> Result<Option<f64>> {
-        let field_idx = self.field_idx_from_name(field_name)?;
-
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
-            return Ok(None);
-        }
-
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsDouble(self.c_feature, field_idx) };
+        let value = unsafe { gdal_sys::OGR_F_GetFieldAsInteger64(self.c_feature, idx) };
 
         Ok(Some(value))
     }
@@ -292,37 +230,20 @@ impl<'a> Feature<'a> {
     /// Returns `Ok(None)` if the field is null.
     /// Returns `Ok(Some(0.))` on other kinds of errors.
     ///
-    pub fn field_as_double(&self, field_idx: i32) -> Result<Option<f64>> {
+    pub fn field_as_double(&self, field_idx: usize) -> Result<Option<f64>> {
         if field_idx >= self.field_count() {
             return Err(GdalError::InvalidFieldIndex {
-                index: field_idx as usize,
+                index: field_idx,
                 method_name: "field_as_double",
             });
         }
 
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
+        let idx = field_idx.try_into()?;
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, idx) } != 0 {
             return Ok(None);
         }
 
-        let value = unsafe { gdal_sys::OGR_F_GetFieldAsDouble(self.c_feature, field_idx) };
-
-        Ok(Some(value))
-    }
-
-    /// Get the value of the specified field as a [`String`].
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// Returns `Ok(None)` if the field is null.
-    ///
-    pub fn field_as_string_by_name(&self, field_name: &str) -> Result<Option<String>> {
-        let field_idx = self.field_idx_from_name(field_name)?;
-
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
-            return Ok(None);
-        }
-
-        let value = _string(unsafe { gdal_sys::OGR_F_GetFieldAsString(self.c_feature, field_idx) });
+        let value = unsafe { gdal_sys::OGR_F_GetFieldAsDouble(self.c_feature, idx) };
 
         Ok(Some(value))
     }
@@ -333,40 +254,20 @@ impl<'a> Feature<'a> {
     ///
     /// Returns `Ok(None)` if the field is null.
     ///
-    pub fn field_as_string(&self, field_idx: i32) -> Result<Option<String>> {
+    pub fn field_as_string(&self, field_idx: usize) -> Result<Option<String>> {
         if field_idx >= self.field_count() {
             return Err(GdalError::InvalidFieldIndex {
-                index: field_idx as usize,
+                index: field_idx,
                 method_name: "field_as_string",
             });
         }
 
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
+        let idx = field_idx.try_into()?;
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, idx) } != 0 {
             return Ok(None);
         }
 
-        let value = _string(unsafe { gdal_sys::OGR_F_GetFieldAsString(self.c_feature, field_idx) });
-
-        Ok(Some(value))
-    }
-
-    /// Get the value of the specified field as a [`DateTime<FixedOffset>`].
-    ///
-    /// If the field is missing, returns [`GdalError::InvalidFieldName`].
-    ///
-    /// Returns `Ok(None)` if the field is null.
-    ///
-    pub fn field_as_datetime_by_name(
-        &self,
-        field_name: &str,
-    ) -> Result<Option<DateTime<FixedOffset>>> {
-        let field_idx = self.field_idx_from_name(field_name)?;
-
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
-            return Ok(None);
-        }
-
-        let value = self._field_as_datetime(field_idx)?;
+        let value = _string(unsafe { gdal_sys::OGR_F_GetFieldAsString(self.c_feature, idx) });
 
         Ok(Some(value))
     }
@@ -377,19 +278,20 @@ impl<'a> Feature<'a> {
     ///
     /// Returns `Ok(None)` if the field is null.
     ///
-    pub fn field_as_datetime(&self, field_idx: i32) -> Result<Option<DateTime<FixedOffset>>> {
+    pub fn field_as_datetime(&self, field_idx: usize) -> Result<Option<DateTime<FixedOffset>>> {
         if field_idx >= self.field_count() {
             return Err(GdalError::InvalidFieldIndex {
-                index: field_idx as usize,
+                index: field_idx,
                 method_name: "field_as_datetime",
             });
         }
 
-        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, field_idx) } != 0 {
+        let idx = field_idx.try_into()?;
+        if unsafe { gdal_sys::OGR_F_IsFieldNull(self.c_feature, idx) } != 0 {
             return Ok(None);
         }
 
-        let value = self._field_as_datetime(field_idx)?;
+        let value = self._field_as_datetime(idx)?;
 
         Ok(Some(value))
     }
@@ -506,14 +408,15 @@ impl<'a> Feature<'a> {
         Ok(())
     }
 
-    pub fn set_field_string(&mut self, field_name: &str, value: &str) -> Result<()> {
+    pub fn set_field_string(&mut self, field_idx: usize, value: &str) -> Result<()> {
         let c_str_value = CString::new(value)?;
-        let idx = self.field_idx_from_name(field_name)?;
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_SetFieldString(self.c_feature, idx, c_str_value.as_ptr()) };
         Ok(())
     }
 
-    pub fn set_field_string_list(&mut self, field_name: &str, value: &[&str]) -> Result<()> {
+    pub fn set_field_string_list(&mut self, field_idx: usize, value: &[&str]) -> Result<()> {
+        let idx = field_idx.try_into()?;
         let c_strings = value
             .iter()
             .map(|&value| CString::new(value))
@@ -526,19 +429,18 @@ impl<'a> Feature<'a> {
         // OGR_F_SetFieldStringList takes a CSLConstList, which is defined as *mut *mut c_char in
         // gdal-sys despite being constant.
         let c_value = c_str_ptrs.as_ptr() as *mut *mut c_char;
-        let idx = self.field_idx_from_name(field_name)?;
         unsafe { gdal_sys::OGR_F_SetFieldStringList(self.c_feature, idx, c_value) };
         Ok(())
     }
 
-    pub fn set_field_double(&mut self, field_name: &str, value: f64) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_double(&mut self, field_idx: usize, value: f64) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_SetFieldDouble(self.c_feature, idx, value as c_double) };
         Ok(())
     }
 
-    pub fn set_field_double_list(&mut self, field_name: &str, value: &[f64]) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_double_list(&mut self, field_idx: usize, value: &[f64]) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe {
             gdal_sys::OGR_F_SetFieldDoubleList(
                 self.c_feature,
@@ -550,14 +452,14 @@ impl<'a> Feature<'a> {
         Ok(())
     }
 
-    pub fn set_field_integer(&mut self, field_name: &str, value: i32) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_integer(&mut self, field_idx: usize, value: i32) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_SetFieldInteger(self.c_feature, idx, value as c_int) };
         Ok(())
     }
 
-    pub fn set_field_integer_list(&mut self, field_name: &str, value: &[i32]) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_integer_list(&mut self, field_idx: usize, value: &[i32]) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe {
             gdal_sys::OGR_F_SetFieldIntegerList(
                 self.c_feature,
@@ -569,14 +471,14 @@ impl<'a> Feature<'a> {
         Ok(())
     }
 
-    pub fn set_field_integer64(&mut self, field_name: &str, value: i64) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_integer64(&mut self, field_idx: usize, value: i64) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_SetFieldInteger64(self.c_feature, idx, value as c_longlong) };
         Ok(())
     }
 
-    pub fn set_field_integer64_list(&mut self, field_name: &str, value: &[i64]) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_integer64_list(&mut self, field_idx: usize, value: &[i64]) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe {
             gdal_sys::OGR_F_SetFieldInteger64List(
                 self.c_feature,
@@ -590,11 +492,10 @@ impl<'a> Feature<'a> {
 
     pub fn set_field_datetime(
         &mut self,
-        field_name: &str,
+        field_idx: usize,
         value: DateTime<FixedOffset>,
     ) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
-
+        let idx = field_idx.try_into()?;
         let year = value.year() as c_int;
         let month = value.month() as c_int;
         let day = value.day() as c_int;
@@ -623,21 +524,21 @@ impl<'a> Feature<'a> {
         Ok(())
     }
 
-    pub fn set_field(&mut self, field_name: &str, value: &FieldValue) -> Result<()> {
+    pub fn set_field(&mut self, field_idx: usize, value: &FieldValue) -> Result<()> {
         match value {
-            FieldValue::IntegerValue(value) => self.set_field_integer(field_name, *value),
-            FieldValue::IntegerListValue(value) => self.set_field_integer_list(field_name, value),
-            FieldValue::Integer64Value(value) => self.set_field_integer64(field_name, *value),
+            FieldValue::IntegerValue(value) => self.set_field_integer(field_idx, *value),
+            FieldValue::IntegerListValue(value) => self.set_field_integer_list(field_idx, value),
+            FieldValue::Integer64Value(value) => self.set_field_integer64(field_idx, *value),
             FieldValue::Integer64ListValue(value) => {
-                self.set_field_integer64_list(field_name, value)
+                self.set_field_integer64_list(field_idx, value)
             }
-            FieldValue::StringValue(ref value) => self.set_field_string(field_name, value.as_str()),
+            FieldValue::StringValue(ref value) => self.set_field_string(field_idx, value.as_str()),
             FieldValue::StringListValue(ref value) => {
                 let strs = value.iter().map(String::as_str).collect::<Vec<&str>>();
-                self.set_field_string_list(field_name, &strs)
+                self.set_field_string_list(field_idx, &strs)
             }
-            FieldValue::RealValue(value) => self.set_field_double(field_name, *value),
-            FieldValue::RealListValue(value) => self.set_field_double_list(field_name, value),
+            FieldValue::RealValue(value) => self.set_field_double(field_idx, *value),
+            FieldValue::RealListValue(value) => self.set_field_double_list(field_idx, value),
             FieldValue::DateValue(value) => {
                 let dv = value
                     .and_hms_opt(0, 0, 0)
@@ -647,9 +548,9 @@ impl<'a> Feature<'a> {
                     FixedOffset::east_opt(0)
                         .ok_or_else(|| GdalError::DateError("utc offset".into()))?,
                 );
-                self.set_field_datetime(field_name, dt)
+                self.set_field_datetime(field_idx, dt)
             }
-            FieldValue::DateTimeValue(value) => self.set_field_datetime(field_name, *value),
+            FieldValue::DateTimeValue(value) => self.set_field_datetime(field_idx, *value),
         }
     }
 
@@ -658,8 +559,8 @@ impl<'a> Feature<'a> {
     /// See: [`OGRFeature::SetFieldNull`][SetFieldNull]
     ///
     /// [SetFieldNull]: https://gdal.org/api/ogrfeature_cpp.html#_CPPv4N10OGRFeature12SetFieldNullEi
-    pub fn set_field_null(&mut self, field_name: &str) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn set_field_null(&mut self, field_idx: usize) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_SetFieldNull(self.c_feature(), idx) };
         Ok(())
     }
@@ -669,8 +570,8 @@ impl<'a> Feature<'a> {
     /// See: [`OGRFeature::UnsetField`][UnsetField]
     ///
     /// [UnsetField]: https://gdal.org/api/ogrfeature_cpp.html#_CPPv4N10OGRFeature10UnsetFieldEi
-    pub fn unset_field(&mut self, field_name: &str) -> Result<()> {
-        let idx = self.field_idx_from_name(field_name)?;
+    pub fn unset_field(&mut self, field_idx: usize) -> Result<()> {
+        let idx = field_idx.try_into()?;
         unsafe { gdal_sys::OGR_F_UnsetField(self.c_feature(), idx) };
         Ok(())
     }
@@ -687,8 +588,9 @@ impl<'a> Feature<'a> {
         Ok(())
     }
 
-    pub fn field_count(&self) -> i32 {
-        unsafe { gdal_sys::OGR_F_GetFieldCount(self.c_feature) }
+    pub fn field_count(&self) -> usize {
+        let count = unsafe { gdal_sys::OGR_F_GetFieldCount(self.c_feature) };
+        count as usize
     }
 
     pub fn fields(&self) -> FieldValueIterator {
@@ -698,8 +600,8 @@ impl<'a> Feature<'a> {
 
 pub struct FieldValueIterator<'a> {
     feature: &'a Feature<'a>,
-    idx: i32,
-    count: i32,
+    idx: usize,
+    count: usize,
 }
 
 impl<'a> FieldValueIterator<'a> {
@@ -721,12 +623,12 @@ impl<'a> Iterator for FieldValueIterator<'a> {
         if idx < self.count {
             self.idx += 1;
             let field_defn =
-                unsafe { gdal_sys::OGR_F_GetFieldDefnRef(self.feature.c_feature, idx) };
+                unsafe { gdal_sys::OGR_F_GetFieldDefnRef(self.feature.c_feature, idx as c_int) };
             let field_name = unsafe { gdal_sys::OGR_Fld_GetNameRef(field_defn) };
             let name = _string(field_name);
             let fv: Option<(String, Option<FieldValue>)> = self
                 .feature
-                .field_from_id(idx)
+                .field(idx)
                 .ok()
                 .map(|field_value| (name, field_value));
             //skip unknown types
@@ -740,10 +642,7 @@ impl<'a> Iterator for FieldValueIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match Some(self.count).and_then(|s| s.try_into().ok()) {
-            Some(size) => (size, Some(size)),
-            None => (0, None),
-        }
+        (self.count, Some(self.count))
     }
 }
 
@@ -958,8 +857,9 @@ mod tests {
 
         let mut layer = ds.layers().next().expect("layer");
         let mut feature = layer.features().next().expect("feature");
-        feature.set_field_null("highway").unwrap();
-        assert!(feature.field("highway").unwrap().is_none());
+        let highway_idx = feature.field_index("highway").unwrap();
+        feature.set_field_null(highway_idx).unwrap();
+        assert!(feature.field(highway_idx).unwrap().is_none());
     }
 
     #[test]
@@ -968,6 +868,7 @@ mod tests {
 
         let mut layer = ds.layers().next().expect("layer");
         let mut feature = layer.features().next().expect("feature");
-        feature.unset_field("highway").unwrap();
+        let highway_idx = feature.field_index("highway").unwrap();
+        feature.unset_field(highway_idx).unwrap();
     }
 }

--- a/src/vector/sql.rs
+++ b/src/vector/sql.rs
@@ -83,12 +83,13 @@ impl Dataset {
     /// let ds = Dataset::open(Path::new("fixtures/roads.geojson")).unwrap();
     /// let query = "SELECT kind, is_bridge, highway FROM roads WHERE highway = 'pedestrian'";
     /// let mut result_set = ds.execute_sql(query, None, sql::Dialect::DEFAULT).unwrap().unwrap();
+    /// let highway_idx = result_set.defn().field_index("highway").unwrap();
     ///
     /// assert_eq!(10, result_set.feature_count());
     ///
     /// for feature in result_set.features() {
     ///     let highway = feature
-    ///         .field("highway")
+    ///         .field(highway_idx)
     ///         .unwrap()
     ///         .unwrap()
     ///         .into_string()
@@ -177,6 +178,7 @@ mod tests {
             .execute_sql(query, None, sql::Dialect::DEFAULT)
             .unwrap()
             .unwrap();
+        let highway_idx = result_set.defn().field_index("highway").unwrap();
 
         let field_names: HashSet<_> = result_set
             .defn()
@@ -194,7 +196,7 @@ mod tests {
 
         for feature in result_set.features() {
             let highway = feature
-                .field("highway")
+                .field(highway_idx)
                 .unwrap()
                 .unwrap()
                 .into_string()
@@ -213,6 +215,7 @@ mod tests {
             .execute_sql(query, Some(&bbox), sql::Dialect::DEFAULT)
             .unwrap()
             .unwrap();
+        let highway_idx = result_set.defn().field_index("highway").unwrap();
 
         assert_eq!(2, result_set.feature_count());
         let mut correct_fids = HashSet::new();
@@ -222,7 +225,7 @@ mod tests {
         let mut fids = HashSet::new();
         for feature in result_set.features() {
             let highway = feature
-                .field("highway")
+                .field(highway_idx)
                 .unwrap()
                 .unwrap()
                 .into_string()
@@ -245,12 +248,13 @@ mod tests {
             .execute_sql(query, Some(&bbox), sql::Dialect::SQLITE)
             .unwrap()
             .unwrap();
+        let highway_idx = result_set.defn().field_index("highway").unwrap();
 
         assert_eq!(1, result_set.feature_count());
         let mut features: Vec<_> = result_set.features().collect();
         let feature = features.pop().unwrap();
         let highway = feature
-            .field("highway")
+            .field(highway_idx)
             .unwrap()
             .unwrap()
             .into_string()


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Field access by name tends to be very slow (I've seen it take 30% of the time in some programs), but beginners are unlikely to realize that they're doing a number of expensive lookups per feature.

Summary of changes:

 - drop field getters that take a field name
 - change the field setters to take an index instead of a name (the index versions were missing)
 - make `field_count` return `usize` for consistency
 - add `Defn::field_index` and make `Feature::field_index` public
 - drop `LayerAccess::create_feature_fields` (it could be updated, but it's a bit weird)