### PR TITLE
Add `Dataset::has_capability`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
   - Add methods `alternative_name`, `is_nullable`, `is_unique`, `default_value` to `Field` ([#561](https://github.com/georust/gdal/pull/561))
   - Add `Defn::geometry_type` ([#562](https://github.com/georust/gdal/pull/562))
   - Add `Defn::field_index` and `Feature::field_index` ([#581](https://github.com/georust/gdal/pull/581))
+  - Add `Dataset::has_capability` for dataset capability check ([#581](https://github.com/georust/gdal/pull/585))
 
 ### Fixed
 

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -41,7 +41,7 @@ pub enum LayerCaps {
     OLCAlterFieldDefn,
     /// Layer capability for transactions
     OLCTransactions,
-    /// Layer capability for feature deletiond
+    /// Layer capability for feature deletion
     OLCDeleteFeature,
     /// Layer capability for setting next feature index
     OLCFastSetNextByIndex,


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is for doing things like `Dataset::has_capability(DatasetCaps::ODsCTransactions)` to check if dataset supports Transaction. 

I added the Capabilities from:
- https://gdal.org/en/latest/doxygen/ogr__api_8h.html#a9010219bbc2e32627064ed860048d979
- https://gdal.org/en/latest/doxygen/gdal_8h.html#a8dc635a536f123e1b03004dc74b4da86

I followed the example of `Layer::has_capability` for both of them.

This will help use the `if {} else {}` block for capability based logic like the one mentioned in #582 

Basically it'll make it so that @lnicola 's Suggestion given below can work:
```rust
let stuffs = |d: &Dataset| -> Result<()> { ... };
if /* transactions are supported */ {
    let txn = d.start_transaction()?;
    stuffs(&txn)?;
    txn.commit()?;
} else {
    stuffs(&d)?;
}
```

Currently, without this function, we have to wait for the result of `Dataset::start_transaction` to know if it supports it, in which case we cannot use `if () {} else {}` block due to Rust's borrow rules as the `Dataset::start_transaction` will take `&mut Dataset`.