### PR TITLE
Make string conversion fallible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
   - Update `Feature::field_count` to return `usize` instead of `i32` ([#581](https://github.com/georust/gdal/pull/581))
   - Update `Feature::field_as_integer`, `Feature::field_as_integer64`, `Feature::field_as_double`, `Feature::field_as_string`, `Feature::field_as_datetime` to take the field index as `usize` instead of `i32` ([#581](https://github.com/georust/gdal/pull/581))
   - Drop `LayerAccess::create_feature_fields` ([#581](https://github.com/georust/gdal/pull/581))
+  - Update `SpatialRef::auth_name`, `SpatialRef::name`, `SpatialRef::angular_units_name`, `SpatialRef::linear_units_name` to return `Option<String>` instead of `Result<String>` ([#589](https://github.com/georust/gdal/pull/589))
 
 ### Added
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ pub fn get_config_option(key: &str, default: &str) -> Result<String> {
     let c_key = CString::new(key.as_bytes())?;
     let c_default = CString::new(default.as_bytes())?;
     let rv = unsafe { gdal_sys::CPLGetConfigOption(c_key.as_ptr(), c_default.as_ptr()) };
-    Ok(_string(rv))
+    Ok(_string(rv).unwrap_or_else(|| default.to_string()))
 }
 
 /// Clear the value of a GDAL library configuration option
@@ -96,7 +96,7 @@ pub fn get_thread_local_config_option(key: &str, default: &str) -> Result<String
     let c_key = CString::new(key.as_bytes())?;
     let c_default = CString::new(default.as_bytes())?;
     let rv = unsafe { gdal_sys::CPLGetThreadLocalConfigOption(c_key.as_ptr(), c_default.as_ptr()) };
-    Ok(_string(rv))
+    Ok(_string(rv).unwrap_or_else(|| default.to_string()))
 }
 
 /// Clear the value of a GDAL library configuration option
@@ -141,7 +141,7 @@ where
         error_num: CPLErrorNum,
         error_msg_ptr: *const c_char,
     ) {
-        let error_msg = _string(error_msg_ptr);
+        let error_msg = _string(error_msg_ptr).unwrap_or_default();
         let error_type: CplErrType = error_type.into();
 
         // reconstruct callback from user data pointer

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -208,7 +208,7 @@ impl Dataset {
     /// Fetch the projection definition string for this dataset.
     pub fn projection(&self) -> String {
         let rv = unsafe { gdal_sys::GDALGetProjectionRef(self.c_dataset) };
-        _string(rv)
+        _string(rv).unwrap_or_default()
     }
 
     /// Set the projection reference string for this dataset.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -66,7 +66,7 @@ impl Driver {
     /// See also: [`long_name`](Self::long_name).
     pub fn short_name(&self) -> String {
         let rv = unsafe { gdal_sys::GDALGetDriverShortName(self.c_driver) };
-        _string(rv)
+        _string(rv).unwrap_or_default()
     }
 
     /// Return the short name of a driver.
@@ -76,7 +76,7 @@ impl Driver {
     /// See also: [`short_name`](Self::short_name`).
     pub fn long_name(&self) -> String {
         let rv = unsafe { gdal_sys::GDALGetDriverLongName(self.c_driver) };
-        _string(rv)
+        _string(rv).unwrap_or_default()
     }
 
     /// Create a new dataset of size (`size_x`, `size_y`) and `bands` band count,

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -81,8 +81,10 @@ impl GcpRef<'_> {
 impl From<&gdal_sys::GDAL_GCP> for Gcp {
     fn from(gcp: &gdal_sys::GDAL_GCP) -> Self {
         Gcp {
-            id: _string(gcp.pszId),
-            info: _string(gcp.pszId),
+            // This seems to never be NULL
+            id: _string(gcp.pszId).unwrap_or_default(),
+            // GDAL docs state that `pszInfo` is filled in or `""`
+            info: _string(gcp.pszInfo).unwrap_or_default(),
             pixel: gcp.dfGCPPixel,
             line: gcp.dfGCPLine,
             x: gcp.dfGCPX,
@@ -133,10 +135,7 @@ impl Dataset {
     ///  See: [`GDALGetGCPProjection`](https://gdal.org/api/raster_c_api.html#gdal_8h_1a85ffa184d3ecb7c0a59a66096b22b2ec)
     pub fn gcp_projection(&self) -> Option<String> {
         let cc_ptr = unsafe { gdal_sys::GDALGetGCPProjection(self.c_dataset()) };
-        if cc_ptr.is_null() {
-            return None;
-        }
-        Some(_string(cc_ptr))
+        _string(cc_ptr)
     }
 
     /// Fetch GCPs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! use gdal::Dataset;
 //! # fn main() -> gdal::errors::Result<()> {
 //! let ds = Dataset::open("fixtures/m_3607824_se_17_1_20160620_sub.tif")?;
-//! println!("This {} is in '{}' and has {} bands.", ds.driver().long_name(), ds.spatial_ref()?.name()?, ds.raster_count());
+//! println!("This {} is in '{}' and has {} bands.", ds.driver().long_name(), ds.spatial_ref()?.name().unwrap(), ds.raster_count());
 //! # Ok(())
 //! # }
 //! ```

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -59,10 +59,7 @@ pub trait Metadata: MajorObject {
     /// ```
     fn description(&self) -> Result<String> {
         let c_res = unsafe { gdal_sys::GDALGetDescription(self.gdal_object_ptr()) };
-        if c_res.is_null() {
-            return Err(_last_null_pointer_err("GDALGetDescription"));
-        }
-        Ok(_string(c_res))
+        _string(c_res).ok_or_else(|| _last_null_pointer_err("GDALGetDescription"))
     }
 
     /// Metadata in GDAL is partitioned into namespaces, knows as "domains" in the
@@ -150,9 +147,7 @@ pub trait Metadata: MajorObject {
                         c_domain.as_ptr(),
                     )
                 };
-                if !c_res.is_null() {
-                    return Some(_string(c_res));
-                }
+                return _string(c_res);
             }
         }
         None

--- a/src/raster/rasterband.rs
+++ b/src/raster/rasterband.rs
@@ -950,13 +950,8 @@ impl<'a> RasterBand<'a> {
     /// Return the unit of the rasterband.
     /// If there is no unit, the empty string is returned.
     pub fn unit(&self) -> String {
-        let str_ptr = unsafe { gdal_sys::GDALGetRasterUnitType(self.c_rasterband) };
-
-        if str_ptr.is_null() {
-            return String::new();
-        }
-
-        _string(str_ptr)
+        let c_ptr = unsafe { gdal_sys::GDALGetRasterUnitType(self.c_rasterband) };
+        _string(c_ptr).unwrap_or_default()
     }
 
     /// Read the band mask flags for a GDAL `RasterBand`.
@@ -1362,8 +1357,8 @@ impl ColorInterpretation {
 
     /// Returns the name of this color interpretation.
     pub fn name(&self) -> String {
-        let rv = unsafe { gdal_sys::GDALGetColorInterpretationName(self.c_int()) };
-        _string(rv)
+        let c_ptr = unsafe { gdal_sys::GDALGetColorInterpretationName(self.c_int()) };
+        _string(c_ptr).unwrap_or_default()
     }
 }
 

--- a/src/raster/types.rs
+++ b/src/raster/types.rs
@@ -103,15 +103,7 @@ impl GdalDataType {
     /// ```
     pub fn name(&self) -> String {
         let c_str = unsafe { GDALGetDataTypeName(self.gdal_ordinal()) };
-        if c_str.is_null() {
-            // This case shouldn't happen, because `self` only exists for valid
-            // GDALDataType ordinals.
-            panic!(
-                "GDALGetDataTypeName unexpectedly returned an empty name for {:?}",
-                &self
-            );
-        }
-        _string(c_str)
+        _string(c_str).unwrap_or_default()
     }
 
     /// Get the [`GDALDataType`] size in **bits**.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,35 +5,40 @@ use gdal_sys::CPLErr;
 
 use crate::errors::*;
 
-pub fn _string(raw_ptr: *const c_char) -> String {
-    let c_str = unsafe { CStr::from_ptr(raw_ptr) };
-    c_str.to_string_lossy().into_owned()
+/// Makes a copy of a C string, returns `None` for a null pointer.
+pub fn _string(raw_ptr: *const c_char) -> Option<String> {
+    if raw_ptr.is_null() {
+        None
+    } else {
+        let c_str = unsafe { CStr::from_ptr(raw_ptr) };
+        Some(c_str.to_string_lossy().into_owned())
+    }
 }
 
-pub(crate) fn _string_tuple(raw_ptr: *const c_char, delim: char) -> Option<(String, String)> {
-    let c_str = unsafe { CStr::from_ptr(raw_ptr) };
-    c_str
-        .to_string_lossy()
-        .split_once(delim)
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-}
-
+/// Converts an array of C strings to Rust `String`s, skipping any null pointers.
 pub fn _string_array(raw_ptr: *mut *mut c_char) -> Vec<String> {
     _convert_raw_ptr_array(raw_ptr, _string)
 }
 
-pub fn _pathbuf(raw_ptr: *const c_char) -> PathBuf {
-    let c_str = unsafe { CStr::from_ptr(raw_ptr) };
-    c_str.to_string_lossy().into_owned().into()
+/// Makes a `PathBuf` from a C string, returns `None` for a null pointer.
+pub fn _pathbuf(raw_ptr: *const c_char) -> Option<PathBuf> {
+    if raw_ptr.is_null() {
+        None
+    } else {
+        let c_str = unsafe { CStr::from_ptr(raw_ptr) };
+        Some(c_str.to_string_lossy().into_owned().into())
+    }
 }
 
+/// Converts an array of C strings to Rust `PathBuf`s, skipping any null pointers.
 pub fn _pathbuf_array(raw_ptr: *mut *mut c_char) -> Vec<PathBuf> {
     _convert_raw_ptr_array(raw_ptr, _pathbuf)
 }
 
+/// Converts an array of C strings, skipping any null pointers.
 fn _convert_raw_ptr_array<F, R>(raw_ptr: *mut *mut c_char, convert: F) -> Vec<R>
 where
-    F: Fn(*const c_char) -> R,
+    F: Fn(*const c_char) -> Option<R>,
 {
     let mut ret_val = Vec::new();
     let mut i = 0;
@@ -47,9 +52,10 @@ where
             if next.is_null() {
                 break;
             }
-            let value = convert(next);
+            if let Some(value) = convert(next) {
+                ret_val.push(value);
+            }
             i += 1;
-            ret_val.push(value);
         }
     }
     ret_val
@@ -63,7 +69,7 @@ pub fn _last_cpl_err(cpl_err_class: CPLErr::Type) -> GdalError {
     GdalError::CplError {
         class: cpl_err_class,
         number: last_err_no,
-        msg: last_err_msg,
+        msg: last_err_msg.unwrap_or_default(),
     }
 }
 
@@ -72,7 +78,7 @@ pub fn _last_null_pointer_err(method_name: &'static str) -> GdalError {
     unsafe { gdal_sys::CPLErrorReset() };
     GdalError::NullPointer {
         method_name,
-        msg: last_err_msg,
+        msg: last_err_msg.unwrap_or_default(),
     }
 }
 

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -170,11 +170,7 @@ impl Geometry {
         // Note: C API makes no statements about this possibly returning null.
         // So we don't have to result wrap this,
         let c_str = unsafe { gdal_sys::OGR_G_GetGeometryName(self.c_geometry()) };
-        if c_str.is_null() {
-            "".into()
-        } else {
-            _string(c_str)
-        }
+        _string(c_str).unwrap_or_default()
     }
 
     /// Get the number of elements in a geometry, or number of geometries in container.
@@ -358,9 +354,7 @@ impl Eq for Geometry {}
 
 pub fn geometry_type_to_name(ty: OGRwkbGeometryType::Type) -> String {
     let rv = unsafe { gdal_sys::OGRGeometryTypeToName(ty) };
-    // If the type is invalid, OGRGeometryTypeToName returns a valid string anyway.
-    assert!(!rv.is_null());
-    _string(rv)
+    _string(rv).unwrap_or_default()
 }
 
 /// Reference to owned geometry

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -284,7 +284,7 @@ pub trait LayerAccess: Sized {
     /// Get the name of this layer.
     fn name(&self) -> String {
         let rv = unsafe { gdal_sys::OGR_L_GetName(self.c_layer()) };
-        _string(rv)
+        _string(rv).unwrap_or_default()
     }
 
     fn has_capability(&self, capability: LayerCaps) -> bool {

--- a/src/vector/ops/conversions/formats.rs
+++ b/src/vector/ops/conversions/formats.rs
@@ -92,8 +92,8 @@ impl Geometry {
                 method_name: "OGR_G_ExportToWkt",
             });
         }
-        let wkt = _string(c_wkt);
-        unsafe { gdal_sys::OGRFree(c_wkt as *mut c_void) };
+        let wkt = _string(c_wkt).unwrap_or_default();
+        unsafe { gdal_sys::VSIFree(c_wkt as *mut c_void) };
         Ok(wkt)
     }
 
@@ -122,12 +122,9 @@ impl Geometry {
     /// See: [`OGR_G_ExportToJson`](https://gdal.org/api/vector_c_api.html#_CPPv418OGR_G_ExportToJson12OGRGeometryH)
     pub fn json(&self) -> Result<String> {
         let c_json = unsafe { gdal_sys::OGR_G_ExportToJson(self.c_geometry()) };
-        if c_json.is_null() {
-            return Err(_last_null_pointer_err("OGR_G_ExportToJson"));
-        };
-        let rv = _string(c_json);
+        let rv = _string(c_json).ok_or_else(|| _last_null_pointer_err("OGR_G_ExportToJson"));
         unsafe { gdal_sys::VSIFree(c_json as *mut c_void) };
-        Ok(rv)
+        rv
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -54,7 +54,8 @@ use std::fmt::Write;
 /// Details: [`const char *GDALVersionInfo(const char*)`](https://gdal.org/api/raster_c_api.html#_CPPv415GDALVersionInfoPKc)
 pub fn version_info(key: &str) -> String {
     let c_key = CString::new(key.as_bytes()).unwrap();
-    _string(unsafe { gdal_sys::GDALVersionInfo(c_key.as_ptr()) })
+    let rv = unsafe { gdal_sys::GDALVersionInfo(c_key.as_ptr()) };
+    _string(rv).unwrap_or_default()
 }
 
 /// Convenience functions for the various pre-defined queryable properties of GDAL version information.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Closes #588

This makes `_string` and `_pathbuf` fallible and updates the callers to some sensible defaults (by returning empty strings in many places, which seems similar in spirit to what GDAL does). There's an API change on `SpatialRef::authority_name` and some friends, which used to return `Result`, but where `Option` feels more appropriate for what they're doing. It might be a little annoying for the users, though.