### PR TITLE
Remove stale pre-GDAL 3 feature gates

### DIFF
--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -218,7 +218,6 @@ impl Dataset {
         Ok(())
     }
 
-    #[cfg(major_ge_3)]
     /// Get the spatial reference system for this dataset.
     pub fn spatial_ref(&self) -> Result<SpatialRef> {
         unsafe {
@@ -234,7 +233,6 @@ impl Dataset {
         }
     }
 
-    #[cfg(major_ge_3)]
     /// Set the spatial reference system for this dataset.
     pub fn set_spatial_ref(&mut self, spatial_ref: &SpatialRef) -> Result<()> {
         let rv = unsafe { gdal_sys::GDALSetSpatialRef(self.c_dataset, spatial_ref.to_c_hsrs()) };

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -283,7 +283,6 @@ impl SpatialRef {
         }
     }
 
-    #[cfg(major_ge_3)]
     pub fn name(&self) -> Result<String> {
         let c_ptr = unsafe { gdal_sys::OSRGetName(self.0) };
         if c_ptr.is_null() {
@@ -402,7 +401,6 @@ impl SpatialRef {
         unsafe { gdal_sys::OSRGetAxesCount(self.0) }
     }
 
-    #[cfg(major_ge_3)]
     /// Set the data axis to CRS axis mapping strategy.
     ///
     /// # Notes
@@ -420,7 +418,6 @@ impl SpatialRef {
         }
     }
 
-    #[cfg(major_ge_3)]
     /// Return the data axis to CRS axis mapping strategy.
     ///
     /// See: [`OSRGetAxisMappingStrategy`](https://gdal.org/api/ogrspatialref.html#_CPPv4NK19OGRSpatialReference22GetAxisMappingStrategyEv)
@@ -429,7 +426,6 @@ impl SpatialRef {
         id.try_into().expect("valid enumeration ordinal from GDAL")
     }
 
-    #[cfg(major_ge_3)]
     /// Get the valid use bounding area for this `SpatialRef`.
     ///
     /// See: [`OSRGetAreaOfUse`](https://gdal.org/api/ogr_srs_api.html#_CPPv415OSRGetAreaOfUse20OGRSpatialReferenceHPdPdPdPdPPKc)
@@ -615,7 +611,6 @@ pub struct AreaOfUse {
     pub name: String,
 }
 
-#[cfg(major_ge_3)]
 /// Data axis to CRS axis mapping strategy.
 ///
 /// See: [`OSRGetAxisMappingStrategy`](https://gdal.org/api/ogrspatialref.html#_CPPv4NK19OGRSpatialReference22GetAxisMappingStrategyEv)
@@ -694,9 +689,6 @@ mod tests {
         let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
         let wkt = spatial_ref.to_wkt().unwrap();
         // TODO: handle proj changes on lib level
-        #[cfg(not(major_ge_3))]
-        assert_eq!("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]", wkt);
-        #[cfg(major_ge_3)]
         assert_eq!("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]", wkt);
         let proj4string = spatial_ref.to_proj4().unwrap();
         assert_eq!("+proj=longlat +datum=WGS84 +no_defs", proj4string.trim());
@@ -794,7 +786,6 @@ mod tests {
         assert_eq!(spatial_ref.auth_code().unwrap(), 32632);
     }
 
-    #[cfg(major_ge_3)]
     #[test]
     fn axis_mapping_strategy() {
         let mut spatial_ref = SpatialRef::from_epsg(4326).unwrap();
@@ -809,7 +800,6 @@ mod tests {
         );
     }
 
-    #[cfg(major_ge_3)]
     #[test]
     fn area_of_use() {
         let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
@@ -820,7 +810,6 @@ mod tests {
         assert_almost_eq(area_of_use.north_lat_degree, 90.0);
     }
 
-    #[cfg(major_ge_3)]
     #[test]
     fn get_name() {
         let spatial_ref = SpatialRef::from_epsg(4326).unwrap();
@@ -870,8 +859,6 @@ mod tests {
         assert!(!spatial_ref_2154.is_derived_geographic());
     }
 
-    //XXX Gdal 2 implementation is partial
-    #[cfg(major_ge_3)]
     #[test]
     fn crs_axis() {
         let spatial_ref = SpatialRef::from_epsg(4326).unwrap();

--- a/src/spatial_ref/transform.rs
+++ b/src/spatial_ref/transform.rs
@@ -274,9 +274,7 @@ mod tests {
         let mut spatial_ref2 = SpatialRef::from_epsg(3035).unwrap();
 
         // TODO: handle axis order in tests
-        #[cfg(major_ge_3)]
         spatial_ref1.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
-        #[cfg(major_ge_3)]
         spatial_ref2.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
 
         let transform = CoordTransform::new(&spatial_ref1, &spatial_ref2).unwrap();
@@ -307,9 +305,7 @@ mod tests {
         let mut spatial_ref2 = SpatialRef::from_wkt("GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",7030]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",6326]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]],UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",4326]]").unwrap();
 
         // TODO: handle axis order in tests
-        #[cfg(major_ge_3)]
         spatial_ref1.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
-        #[cfg(major_ge_3)]
         spatial_ref2.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
 
         let htransform = CoordTransform::new(&spatial_ref2, &spatial_ref1).unwrap();
@@ -323,9 +319,7 @@ mod tests {
         let mut dhd_2 = SpatialRef::from_epsg(31462).unwrap();
 
         // TODO: handle axis order in tests
-        #[cfg(major_ge_3)]
         wgs84.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
-        #[cfg(major_ge_3)]
         dhd_2.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
 
         let mut x = [1979105.06, 0.0];
@@ -340,9 +334,7 @@ mod tests {
         let mut webmercator = SpatialRef::from_epsg(3857).unwrap();
 
         // TODO: handle axis order in tests
-        #[cfg(major_ge_3)]
         wgs84.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
-        #[cfg(major_ge_3)]
         webmercator.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
 
         let mut x = [1000000.0];

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -1510,7 +1510,6 @@ mod tests {
 
         let geom_field = layer.defn().geom_fields().next().unwrap();
         let mut spatial_ref2 = SpatialRef::from_epsg(4326).unwrap();
-        #[cfg(major_ge_3)]
         spatial_ref2.set_axis_mapping_strategy(AxisMappingStrategy::TraditionalGisOrder);
 
         assert_eq!(geom_field.spatial_ref().unwrap(), spatial_ref2);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

These are leftovers from #504, but should have no effect.