### PR TITLE
Disable Valgrind because of leak in 1.83 unit test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,9 @@ jobs:
         run: cargo test --features "default bindgen array" -- --nocapture
       - name: Install cargo-valgrind
         run: cargo install cargo-valgrind
-      - name: Run --lib tests under valgrind
-        run: cargo valgrind test --lib
+      # There's a possible leak in Rust 1.83 and generating suppressions on CI is hard
+      # - name: Run --lib tests under valgrind
+      #   run: cargo valgrind test --lib
 
   gdal_static:
     name: "ci gdal-static"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

