### PR TITLE
Add M-dim bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,10 +28,13 @@
   - Add `Defn::field_index` and `Feature::field_index` ([#581](https://github.com/georust/gdal/pull/581))
   - Add `Defn::geometry_field_index` and `Feature::geometry_field_index` ([#594](https://github.com/georust/gdal/pull/594))
   - Add `Dataset::has_capability` for dataset capability check ([#581](https://github.com/georust/gdal/pull/585))
+  - Add methods `add_point_zm`, `add_point_m`, `set_point_zm`, `set_point_m`, `get_point_zm`, `get_point_vec_zm`, `iso_wkt` and `iso_wkb` to `Geometry` ([#600](https://github.com/georust/gdal/pull/600))
+  - Add functions `geometry_type_flatten`, `geometry_type_set_z`, `geometry_type_set_m`, `geometry_type_set_modifier`, `geometry_type_has_z` and `geometry_type_has_m` to `vector::geometry` ([#600](https://github.com/georust/gdal/pull/600))
 
 ### Fixed
 
   - Fix conversion from `ndarray` when the data is offsetted from the start of the buffer ([#569](https://github.com/georust/gdal/pull/569))
+  - `Debug` trait for `Geometry` now prints ISO WKT when the M-dim is present ([#600](https://github.com/georust/gdal/pull/600))
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@
 ### Fixed
 
   - Fix conversion from `ndarray` when the data is offsetted from the start of the buffer ([#569](https://github.com/georust/gdal/pull/569))
-  - `Debug` trait for `Geometry` now prints ISO WKT when the M-dim is present ([#600](https://github.com/georust/gdal/pull/600))
+  - use ISO WKT for the `Debug` implementation of `Geometry`, in order to properly display measure values,  ([#600](https://github.com/georust/gdal/pull/600))
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
   - Drop `LayerAccess::create_feature_fields` ([#581](https://github.com/georust/gdal/pull/581))
   - Drop `Feature::geometry_by_name` ([#594](https://github.com/georust/gdal/pull/594))
   - Update `SpatialRef::auth_name`, `SpatialRef::name`, `SpatialRef::angular_units_name`, `SpatialRef::linear_units_name` to return `Option<String>` instead of `Result<String>` ([#589](https://github.com/georust/gdal/pull/589))
+  - Update `Geometry::get_point_vec` to modify a `&mut Vec` as opposed to new allocations, returning an `i32` of points added ([#600](https://github.com/georust/gdal/pull/600))
 
 ### Added
 

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -457,7 +457,7 @@ pub fn geometry_type_set_modifier(ty: OGRwkbGeometryType::Type, set_z: bool, set
     unsafe { gdal_sys::OGR_GT_SetModifier(ty, set_z as i32, set_m as i32) }
 }
 
-/// Return if the geometry type is a 3D geometry type. 
+/// Returns `true` if the geometry type is a 3D geometry type. 
 pub fn geometry_type_has_z(ty: OGRwkbGeometryType::Type) -> bool {
     unsafe { gdal_sys::OGR_GT_HasZ(ty) != 0 }
 }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -408,13 +408,7 @@ impl Clone for Geometry {
 
 impl Debug for Geometry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let should_iso = geometry_type_has_m(self.geometry_type());
-
-        // .wkt() does not return the M coordinate regardless or whether or not the Z coordinate is present.
-        let wkt = match should_iso {
-            true => self.iso_wkt(),
-            false => self.wkt()
-        };
+        let wkt = self.iso_wkt();
 
         match wkt {
             Ok(wkt) => f.write_str(wkt.as_str()),

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -219,7 +219,7 @@ impl Geometry {
 
     /// Appends all points of a line string to `out_points`. 
     ///
-    /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
+    /// Only wkbPoint[X], wkbLineString[X] or wkbCircularString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
     pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> usize {
         // Consider replacing logic with
@@ -231,7 +231,7 @@ impl Geometry {
 
     /// Appends all points of a line string to `out_points`. 
     ///
-    /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
+    /// Only wkbPoint[X], wkbLineString[X] or wkbCircularString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
     pub fn get_point_vec_zm(&self, out_points: &mut Vec<(f64, f64, f64, f64)>) -> usize {
         // Consider replacing logic with

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -614,13 +614,10 @@ mod tests {
         point.set_point_zm(0, (4.0, 2.0, 1.0, 1.0));
         geom.add_geometry(point).unwrap();
         assert!(!geom.is_empty());
-
         let expected = Geometry::from_wkt("MULTIPOINT ZM ((1.0 2.0 3.0 0.0), (4.0 2.0 1.0 1.0))").unwrap();
         assert_eq!(geom, expected);
         assert_eq!(geometry_type_has_m(geom.geometry_type()), geometry_type_has_m(expected.geometry_type()))
     }
-
-
 
     #[test]
     pub fn test_spatial_ref() {
@@ -651,11 +648,9 @@ mod tests {
         assert!(!ring.is_empty());
         let mut ring_vec: Vec<(f64, f64, f64)> = Vec::new();
         ring.get_point_vec(&mut ring_vec);
-
         assert_eq!(ring_vec.len(), 6);
         let mut poly = Geometry::empty(wkbPolygon).unwrap();
         poly.add_geometry(ring.to_owned()).unwrap();
-
         let mut poly_vec: Vec<(f64, f64, f64)> = Vec::new();
         poly.get_point_vec(&mut poly_vec);
         // Points are in ring, not containing geometry.
@@ -691,10 +686,8 @@ mod tests {
         line.add_point_zm((0.0, 0.0, 0.0, 0.0));
         line.add_point_zm((1.0, 0.0, 0.25, 0.5));
         line.add_point_zm((1.0, 1.0, 0.5, 1.0));
-
         let mut line_points: Vec<(f64, f64, f64, f64)> = Vec::new();
         line.get_point_vec_zm(&mut line_points);
-
         assert_eq!(line_points.len(), 3);
         assert_eq!(line_points.get(2), Some(&(1.0, 1.0, 0.5, 1.0)));
     }
@@ -725,16 +718,12 @@ mod tests {
     #[test]
     fn test_geometry_type_modification() {
         let mut geom_type = OGRwkbGeometryType::wkbPoint;
-
         geom_type = geometry_type_set_z(geom_type);
         assert_eq!(geom_type, OGRwkbGeometryType::wkbPoint25D);
-
         geom_type = geometry_type_set_m(geom_type);
         assert_eq!(geom_type, OGRwkbGeometryType::wkbPointZM);
-
         geom_type = geometry_type_set_modifier(geom_type, false, true);
         assert_eq!(geom_type, OGRwkbGeometryType::wkbPointM);
-
         geom_type = geometry_type_flatten(geom_type);
         assert_eq!(geom_type, OGRwkbGeometryType::wkbPoint);
     }
@@ -742,17 +731,12 @@ mod tests {
     #[test]
     fn test_geometry_type_has_zm() {
         let geom = Geometry::from_wkt("POINT(0 1)").unwrap();
-
         assert_eq!(geometry_type_has_z(geom.geometry_type()), false);
         assert_eq!(geometry_type_has_m(geom.geometry_type()), false);
-
         let geom = Geometry::from_wkt("POINT(0 1 2)").unwrap();
-
         assert_eq!(geometry_type_has_z(geom.geometry_type()), true);
         assert_eq!(geometry_type_has_m(geom.geometry_type()), false);
-
         let geom = Geometry::from_wkt("POINT ZM (0 1 2 3)").unwrap();
-
         assert_eq!(geometry_type_has_z(geom.geometry_type()), true);
         assert_eq!(geometry_type_has_m(geom.geometry_type()), true);
     }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -221,24 +221,30 @@ impl Geometry {
     ///
     /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
-    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) {
+    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> i32 {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
         out_points.extend(
             (0..length).map(|i| self.get_point(i))
         );
+
+        length
     }
 
     /// Appends all points of a line string to `out_points`. 
     ///
     /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
-    pub fn get_point_vec_zm(&self, out_points: &mut Vec<(f64, f64, f64, f64)>) {
+    pub fn get_point_vec_zm(&self, out_points: &mut Vec<(f64, f64, f64, f64)>) -> i32 {
+        // Consider replacing logic with
+        // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
         out_points.extend(
             (0..length).map(|i| self.get_point_zm(i))
         );
+
+        length
     }
 
     /// Get the geometry type ordinal

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -221,7 +221,7 @@ impl Geometry {
     ///
     /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
-    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> as usize {
+    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> usize {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -225,9 +225,7 @@ impl Geometry {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
-        out_points.extend(
-            (0..length).map(|i| self.get_point(i))
-        );
+        out_points.extend((0..length).map(|i| self.get_point(i)));
 
         length
     }
@@ -240,9 +238,7 @@ impl Geometry {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
-        out_points.extend(
-            (0..length).map(|i| self.get_point_zm(i))
-        );
+        out_points.extend((0..length).map(|i| self.get_point_zm(i)));
 
         length
     }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -221,26 +221,24 @@ impl Geometry {
     ///
     /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
-    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> i32 {
+    pub fn get_point_vec(&self, out_points: &mut Vec<(f64, f64, f64)>) -> as usize {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
         out_points.extend((0..length).map(|i| self.get_point(i)));
-
-        length
+        length as usize
     }
 
     /// Appends all points of a line string to `out_points`. 
     ///
     /// Only wkbPoint[X] or wkbLineString[X] may alter `out_points`. Other geometry types will silently do nothing, see
     /// [`OGR_G_GetPointCount`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv419OGR_G_GetPointCount12OGRGeometryH)
-    pub fn get_point_vec_zm(&self, out_points: &mut Vec<(f64, f64, f64, f64)>) -> i32 {
+    pub fn get_point_vec_zm(&self, out_points: &mut Vec<(f64, f64, f64, f64)>) -> usize {
         // Consider replacing logic with
         // [OGR_G_GetPoints](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv415OGR_G_GetPoints12OGRGeometryHPviPviPvi)
         let length = unsafe { gdal_sys::OGR_G_GetPointCount(self.c_geometry()) };
         out_points.extend((0..length).map(|i| self.get_point_zm(i)));
-
-        length
+        length as usize
     }
 
     /// Get the geometry type ordinal

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -462,7 +462,7 @@ pub fn geometry_type_has_z(ty: OGRwkbGeometryType::Type) -> bool {
     unsafe { gdal_sys::OGR_GT_HasZ(ty) != 0 }
 }
 
-/// Return if the geometry type is a measured type.
+/// Returns `true` if the geometry type is a measured type.
 pub fn geometry_type_has_m(ty: OGRwkbGeometryType::Type) -> bool {
     unsafe { gdal_sys::OGR_GT_HasM(ty) != 0 }
 }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -403,6 +403,16 @@ pub fn geometry_type_to_name(ty: OGRwkbGeometryType::Type) -> String {
     _string(rv).unwrap_or_default()
 }
 
+/// Return if the geometry type is a 3D geometry type. 
+pub fn has_z(ty: OGRwkbGeometryType::Type) -> bool {
+    unsafe { gdal_sys::OGR_GT_HasZ(ty) != 0 }
+}
+
+/// Return if the geometry type is a measured type.
+pub fn has_m(ty: OGRwkbGeometryType::Type) -> bool {
+    unsafe { gdal_sys::OGR_GT_HasM(ty) != 0 }
+}
+
 /// Reference to owned geometry
 pub struct GeometryRef<'a> {
     geom: Geometry,
@@ -624,5 +634,23 @@ mod tests {
             "POLYGON ((300 100,400 400,200 400,100 200,300 100))",
             polygon.wkt().unwrap()
         );
+    }
+
+    #[test]
+    fn test_geometry_type_has_zm() {
+        let geom = Geometry::from_wkt("POINT(0 1)").unwrap();
+
+        assert_eq!(has_z(geom.geometry_type()), false);
+        assert_eq!(has_m(geom.geometry_type()), false);
+
+        let geom = Geometry::from_wkt("POINT Z (0 1 2)").unwrap();
+
+        assert_eq!(has_z(geom.geometry_type()), true);
+        assert_eq!(has_m(geom.geometry_type()), false);
+
+        let geom = Geometry::from_wkt("POINT ZM (0 1 2 3)").unwrap();
+
+        assert_eq!(has_z(geom.geometry_type()), true);
+        assert_eq!(has_m(geom.geometry_type()), true);
     }
 }

--- a/src/vector/geometry.rs
+++ b/src/vector/geometry.rs
@@ -128,6 +128,19 @@ impl Geometry {
         };
     }
 
+    pub fn set_point_m(&mut self, i: usize, point: (f64, f64, f64)) {
+        let (x, y, m) = point;
+        unsafe {
+            gdal_sys::OGR_G_SetPointM(
+                self.c_geometry(),
+                i as c_int,
+                x as c_double,
+                y as c_double,
+                m as c_double,
+            );
+        };
+    }
+
     pub fn set_point_2d(&mut self, i: usize, p: (f64, f64)) {
         let (x, y) = p;
         unsafe {
@@ -160,6 +173,18 @@ impl Geometry {
                 x as c_double,
                 y as c_double,
                 z as c_double,
+                m as c_double,
+            )
+        };
+    }
+
+    pub fn add_point_m(&mut self, p: (f64, f64, f64)) {
+        let (x, y, m) = p;
+        unsafe {
+            gdal_sys::OGR_G_AddPointM(
+                self.c_geometry(),
+                x as c_double,
+                y as c_double,
                 m as c_double,
             )
         };

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -1272,7 +1272,6 @@ mod tests {
             assert_eq!(geom.geometry_type(), OGRwkbGeometryType::wkbLineString);
             let mut coords: Vec<(f64, f64, f64)> = Vec::new();
             geom.get_point_vec(&mut coords);
-
             assert_eq!(
                 coords,
                 [

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -1270,7 +1270,9 @@ mod tests {
         with_feature("roads.geojson", 236194095, |feature| {
             let geom = feature.geometry().unwrap();
             assert_eq!(geom.geometry_type(), OGRwkbGeometryType::wkbLineString);
-            let coords = geom.get_point_vec();
+            let mut coords: Vec<(f64, f64, f64)> = Vec::new();
+            geom.get_point_vec(&mut coords);
+
             assert_eq!(
                 coords,
                 [

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -79,7 +79,7 @@ pub use feature::{
     OwnedFeatureIterator,
 };
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
-pub use geometry::{geometry_type_to_name, has_z, has_m, Geometry};
+pub use geometry::{geometry_type_to_name, geometry_type_flatten, geometry_type_has_z, geometry_type_has_m, Geometry};
 pub use layer::{FieldDefn, Layer, LayerAccess, LayerCaps, LayerIterator, OwnedLayer};
 pub use options::LayerOptions;
 pub use transaction::Transaction;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -79,7 +79,10 @@ pub use feature::{
     OwnedFeatureIterator,
 };
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
-pub use geometry::{geometry_type_to_name, geometry_type_flatten, geometry_type_has_z, geometry_type_has_m, Geometry};
+pub use geometry::{
+    geometry_type_to_name, geometry_type_flatten, geometry_type_set_z, geometry_type_set_m, 
+    geometry_type_set_modifier, geometry_type_has_z, geometry_type_has_m, Geometry
+};
 pub use layer::{FieldDefn, Layer, LayerAccess, LayerCaps, LayerIterator, OwnedLayer};
 pub use options::LayerOptions;
 pub use transaction::Transaction;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -79,7 +79,7 @@ pub use feature::{
     OwnedFeatureIterator,
 };
 pub use gdal_sys::{OGRFieldType, OGRwkbGeometryType};
-pub use geometry::{geometry_type_to_name, Geometry};
+pub use geometry::{geometry_type_to_name, has_z, has_m, Geometry};
 pub use layer::{FieldDefn, Layer, LayerAccess, LayerCaps, LayerIterator, OwnedLayer};
 pub use options::LayerOptions;
 pub use transaction::Transaction;

--- a/src/vector/ops/conversions/formats.rs
+++ b/src/vector/ops/conversions/formats.rs
@@ -177,6 +177,15 @@ mod tests {
     }
 
     #[test]
+    pub fn test_iso_wkb() {
+        let wkt = "POLYGON ZM ((45.0 45.0 0.0 0.0, 45.0 50.0 0.0 0.25, 50.0 50.0 0.0 0.50, 50.0 45.0 0.0 0.75, 45.0 45.0 0.0 1.0))";
+        let orig_geom = Geometry::from_wkt(wkt).unwrap();
+        let wkb = orig_geom.iso_wkb().unwrap();
+        let new_geom = Geometry::from_wkb(&wkb).unwrap();
+        assert_eq!(new_geom, orig_geom);
+    }
+
+    #[test]
     pub fn test_geojson() {
         let json = r#"{ "type": "Point", "coordinates": [10, 20] }"#;
         let geom = Geometry::from_geojson(json).unwrap();

--- a/src/vector/ops/conversions/formats.rs
+++ b/src/vector/ops/conversions/formats.rs
@@ -119,6 +119,8 @@ impl Geometry {
         let wkb_size = unsafe { gdal_sys::OGR_G_WkbSize(self.c_geometry()) as usize };
         // We default to little-endian for now. A WKB string explicitly indicates the byte
         // order, so this is not a problem for interoperability.
+        // 
+        // Consider using `Vec::MaybeUninit` in future.
         let byte_order = gdal_sys::OGRwkbByteOrder::wkbNDR;
         let mut wkb = vec![0; wkb_size];
         let rv =
@@ -139,6 +141,8 @@ impl Geometry {
         let wkb_size = unsafe { gdal_sys::OGR_G_WkbSize(self.c_geometry()) as usize };
         // We default to little-endian for now. A WKB string explicitly indicates the byte
         // order, so this is not a problem for interoperability.
+        //
+        // Consider using `Vec::MaybeUninit` in future.
         let byte_order = gdal_sys::OGRwkbByteOrder::wkbNDR;
         let mut wkb = vec![0; wkb_size];
         let rv =

--- a/src/vector/ops/conversions/formats.rs
+++ b/src/vector/ops/conversions/formats.rs
@@ -97,6 +97,21 @@ impl Geometry {
         Ok(wkt)
     }
 
+    /// Serialize the geometry as SFSQL 1.2 / ISO SQL / MM Part 3 WKT.
+    pub fn iso_wkt(&self) -> Result<String> {
+        let mut c_wkt = null_mut();
+        let rv = unsafe { gdal_sys::OGR_G_ExportToIsoWkt(self.c_geometry(), &mut c_wkt) };
+        if rv != OGRErr::OGRERR_NONE {
+            return Err(GdalError::OgrError {
+                err: rv,
+                method_name: "OGR_G_ExportToIsoWkt",
+            });
+        }
+        let wkt = _string(c_wkt).unwrap_or_default();
+        unsafe { gdal_sys::VSIFree(c_wkt as *mut c_void) };
+        Ok(wkt)
+    }
+
     /// Serializes the geometry to
     /// [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary)
     /// (Well-Known Binary) format.
@@ -112,6 +127,26 @@ impl Geometry {
             return Err(GdalError::OgrError {
                 err: rv,
                 method_name: "OGR_G_ExportToWkb",
+            });
+        }
+        Ok(wkb)
+    }
+
+    /// Serializes the geometry to SFSQL 1.2 / ISO SQL / MM Part 3
+    /// [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary)
+    /// (Well-Known Binary) format.
+    pub fn iso_wkb(&self) -> Result<Vec<u8>> {
+        let wkb_size = unsafe { gdal_sys::OGR_G_WkbSize(self.c_geometry()) as usize };
+        // We default to little-endian for now. A WKB string explicitly indicates the byte
+        // order, so this is not a problem for interoperability.
+        let byte_order = gdal_sys::OGRwkbByteOrder::wkbNDR;
+        let mut wkb = vec![0; wkb_size];
+        let rv =
+            unsafe { gdal_sys::OGR_G_ExportToIsoWkb(self.c_geometry(), byte_order, wkb.as_mut_ptr()) };
+        if rv != gdal_sys::OGRErr::OGRERR_NONE {
+            return Err(GdalError::OgrError {
+                err: rv,
+                method_name: "OGR_G_ExportToIsoWkb",
             });
         }
         Ok(wkb)

--- a/src/vector/ops/conversions/gdal_to_geo.rs
+++ b/src/vector/ops/conversions/gdal_to_geo.rs
@@ -44,11 +44,13 @@ impl TryFrom<&Geometry> for geo_types::Geometry<f64> {
                 )))
             }
             OGRwkbGeometryType::wkbLineString => {
-                let coords = geo
-                    .get_point_vec()
-                    .iter()
-                    .map(|&(x, y, _)| geo_types::Coord { x, y })
+                let mut gdal_coords: Vec<(f64, f64, f64)> = Vec::new();
+                geo.get_point_vec(&mut gdal_coords);
+
+                let coords = gdal_coords.into_iter()
+                    .map(|(x, y, _)| geo_types::Coord { x, y })
                     .collect();
+
                 Ok(geo_types::Geometry::LineString(geo_types::LineString(
                     coords,
                 )))

--- a/src/vector/ops/conversions/gdal_to_geo.rs
+++ b/src/vector/ops/conversions/gdal_to_geo.rs
@@ -46,11 +46,9 @@ impl TryFrom<&Geometry> for geo_types::Geometry<f64> {
             OGRwkbGeometryType::wkbLineString => {
                 let mut gdal_coords: Vec<(f64, f64, f64)> = Vec::new();
                 geo.get_point_vec(&mut gdal_coords);
-
                 let coords = gdal_coords.into_iter()
                     .map(|(x, y, _)| geo_types::Coord { x, y })
                     .collect();
-
                 Ok(geo_types::Geometry::LineString(geo_types::LineString(
                     coords,
                 )))


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This PR seeks to add bindings for GDAL functions relating to higher-dimension geometry, in particular Measured geometry, with some other minor fixes/additions.

Added methods for `Geometry`:
- `add_point_zm`
- `add_point_m`
- `set_point_zm`
- `set_point_m`
- `get_point_zm`
- `get_point_vec_zm`
- `iso_wkt`
- `iso_wkb`

Considering renaming `get_point_vec_zm` to `get_point_zm_vec`, though neither exactly roll off the tongue.

Also modified the Debug impl. for `Geometry` to use iso_wkt in cases of measured geometry.
