### PR TITLE
Allow newer libsqlite3-sys versions

### DIFF
--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -38,7 +38,7 @@ include = [
 [dependencies]
 link-cplusplus = "1.0"
 proj-sys = { version = "0.25.0", features = ["bundled_proj"] }
-libsqlite3-sys = { version = "0.28.0", features = ["bundled"], optional = true }
+libsqlite3-sys = { version = ">=0.28.0,<0.31", features = ["bundled"], optional = true }
 hdf5-sys = { package = "hdf5-metno-sys", version = "0.9.1", optional = true, features = ["static", "hl", "deprecated"] }
 netcdf-sys = { version = "0.8.1", optional = true, features = ["static"] }
 pq-src = { version = "0.3.2", optional = true, default-features = false }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Now that there is a `proj-sys` release that supports these newer versions we can support them in gdal-src as well.

