### PR TITLE
Bump referenced gdal version to 3.10.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 3.10.2
+          - 3.10.3
           - 3.9.3
           - 3.8.5
           - 3.7.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+### Fixed
+
+  - Bump referenced gdal version to 3.10.3
+
 ## 0.18
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "gdal-src"
-version = "0.2.0+3.10.2"
+version = "0.2.1+3.10.3"
 dependencies = [
  "cmake",
  "curl-sys",

--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdal-src"
-version = "0.2.0+3.10.2"
+version = "0.2.1+3.10.3"
 edition = "2021"
 links = "gdal_src"
 description = "Build script for compiling GDAL from source."
@@ -191,7 +191,6 @@ internal_drivers = [
     "driver_xpm",
     "driver_xyz",
     "driver_zmap",
-
     # ogr and gdal
     "driver_idrisi",
     "driver_sdts",


### PR DESCRIPTION
Previous PR #616 reverted the version back from 3.10.2 to 3.9.1

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

