### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["science::geo", "api-bindings"]
 repository = "https://github.com/georust/gdal"
 edition = "2021"
 rust-version = "1.80"
+include = ["CHANGES.md", "Cargo.toml", "README.md", "build.rs", "src/**/*.rs"]
 
 [features]
 default = []

--- a/gdal-src/Cargo.toml
+++ b/gdal-src/Cargo.toml
@@ -41,6 +41,7 @@ include = [
     "/source/ogr/ogrsf_frmts/sxf/data",
     "/source/scripts/gdal-bash-completion.sh",
     "/src/lib.rs",
+    "!/source/swig/python/setup.py.in",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
During a dependency review we noticed that the gdal crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.

There was also one script in gdal-src that is reported by cargo-deny and that could be removed. The other script that's reported unfortunally is required for the build.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/gdal/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

