### PR TITLE
feat: safe wrappers for ignored fields and the PROJ search paths

### DIFF
--- a/src/spatial_ref/mod.rs
+++ b/src/spatial_ref/mod.rs
@@ -13,6 +13,6 @@ mod transform_opts;
 /// See [`OGRAxisOrientation`](https://gdal.org/api/ogr_srs_api.html#_CPPv418OGRAxisOrientation).
 pub type AxisOrientationType = gdal_sys::OGRAxisOrientation::Type;
 
-pub use srs::{AxisMappingStrategy, SpatialRef};
+pub use srs::{get_proj_search_paths, set_proj_search_paths, AxisMappingStrategy, SpatialRef};
 pub use transform::CoordTransform;
 pub use transform_opts::CoordTransformOptions;

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -7,7 +7,7 @@ use std::{
 use gdal_sys::{OGRErr, OSRAxisMappingStrategy};
 
 use crate::errors::*;
-use crate::utils::{_last_null_pointer_err, _string};
+use crate::utils::{_last_null_pointer_err, _string, _string_array};
 
 /// A OpenGIS Spatial Reference System definition.
 ///
@@ -636,6 +636,32 @@ impl TryFrom<u32> for AxisMappingStrategy {
 
 #[cfg(test)]
 mod tests {
+    /// Setting the PROJ search paths replaces them, and reading them back
+    /// reports what was set.
+    ///
+    /// The paths are **process-global**: the test restores whatever was there
+    /// before, so it does not move the ground under the other tests. It also
+    /// runs behind a mutex, because two tests writing a global at the same time
+    /// would make each other flaky rather than fail honestly.
+    #[test]
+    fn test_proj_search_paths() {
+        use std::sync::Mutex;
+        static GUARD: Mutex<()> = Mutex::new(());
+        let _held = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+        let original = super::get_proj_search_paths();
+
+        super::set_proj_search_paths(&["/tmp/proj-one", "/tmp/proj-two"]).unwrap();
+        assert_eq!(
+            super::get_proj_search_paths(),
+            vec!["/tmp/proj-one".to_string(), "/tmp/proj-two".to_string()]
+        );
+
+        let restore: Vec<&str> = original.iter().map(String::as_str).collect();
+        super::set_proj_search_paths(&restore).unwrap();
+        assert_eq!(super::get_proj_search_paths(), original);
+    }
+
     use super::*;
     use crate::assert_almost_eq;
 
@@ -971,4 +997,43 @@ mod tests {
             expected_geog_cs.to_wkt()
         );
     }
+}
+
+/// Set the search path(s) PROJ uses to find its resource files.
+///
+/// This wraps [`OSRSetPROJSearchPaths`], which is already bound in `gdal-sys`
+/// but has no safe wrapper here.  It is *not* the same thing as setting the
+/// `PROJ_DATA` configuration option: GDAL does not forward that option to PROJ,
+/// so a relocatable distribution that only sets the option keeps reading
+/// whatever paths were compiled into PROJ at build time.
+///
+/// The paths replace any previously configured ones, including those taken from
+/// the environment.
+///
+/// [`OSRSetPROJSearchPaths`]: https://gdal.org/api/ogr_srs_api.html#_CPPv421OSRSetPROJSearchPathsPPCKc
+pub fn set_proj_search_paths(paths: &[&str]) -> Result<()> {
+    let owned = paths
+        .iter()
+        .map(|p| CString::new(p.as_bytes()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut raw: Vec<*const std::ffi::c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+    raw.push(std::ptr::null());
+    unsafe { gdal_sys::OSRSetPROJSearchPaths(raw.as_ptr()) };
+    Ok(())
+}
+
+/// The search path(s) PROJ currently uses, as GDAL sees them.
+///
+/// With nothing configured this reports the defaults PROJ was built with, which
+/// makes it the way to learn where the resource files actually live before
+/// overriding the paths.
+#[must_use]
+pub fn get_proj_search_paths() -> Vec<String> {
+    let list = unsafe { gdal_sys::OSRGetPROJSearchPaths() };
+    if list.is_null() {
+        return Vec::new();
+    }
+    let paths = _string_array(list);
+    unsafe { gdal_sys::CSLDestroy(list) };
+    paths
 }

--- a/src/spatial_ref/srs.rs
+++ b/src/spatial_ref/srs.rs
@@ -634,6 +634,45 @@ impl TryFrom<u32> for AxisMappingStrategy {
     }
 }
 
+/// Set the search path(s) PROJ uses to find its resource files.
+///
+/// This wraps [`OSRSetPROJSearchPaths`], which is already bound in `gdal-sys`
+/// but has no safe wrapper here.  It is *not* the same thing as setting the
+/// `PROJ_DATA` configuration option: GDAL does not forward that option to PROJ,
+/// so a relocatable distribution that only sets the option keeps reading
+/// whatever paths were compiled into PROJ at build time.
+///
+/// The paths replace any previously configured ones, including those taken from
+/// the environment.
+///
+/// [`OSRSetPROJSearchPaths`]: https://gdal.org/api/ogr_srs_api.html#_CPPv421OSRSetPROJSearchPathsPPCKc
+pub fn set_proj_search_paths(paths: &[&str]) -> Result<()> {
+    let owned = paths
+        .iter()
+        .map(|p| CString::new(p.as_bytes()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut raw: Vec<*const std::ffi::c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+    raw.push(std::ptr::null());
+    unsafe { gdal_sys::OSRSetPROJSearchPaths(raw.as_ptr()) };
+    Ok(())
+}
+
+/// The search path(s) PROJ currently uses, as GDAL sees them.
+///
+/// With nothing configured this reports the defaults PROJ was built with, which
+/// makes it the way to learn where the resource files actually live before
+/// overriding the paths.
+#[must_use]
+pub fn get_proj_search_paths() -> Vec<String> {
+    let list = unsafe { gdal_sys::OSRGetPROJSearchPaths() };
+    if list.is_null() {
+        return Vec::new();
+    }
+    let paths = _string_array(list);
+    unsafe { gdal_sys::CSLDestroy(list) };
+    paths
+}
+
 #[cfg(test)]
 mod tests {
     /// Setting the PROJ search paths replaces them, and reading them back
@@ -997,43 +1036,4 @@ mod tests {
             expected_geog_cs.to_wkt()
         );
     }
-}
-
-/// Set the search path(s) PROJ uses to find its resource files.
-///
-/// This wraps [`OSRSetPROJSearchPaths`], which is already bound in `gdal-sys`
-/// but has no safe wrapper here.  It is *not* the same thing as setting the
-/// `PROJ_DATA` configuration option: GDAL does not forward that option to PROJ,
-/// so a relocatable distribution that only sets the option keeps reading
-/// whatever paths were compiled into PROJ at build time.
-///
-/// The paths replace any previously configured ones, including those taken from
-/// the environment.
-///
-/// [`OSRSetPROJSearchPaths`]: https://gdal.org/api/ogr_srs_api.html#_CPPv421OSRSetPROJSearchPathsPPCKc
-pub fn set_proj_search_paths(paths: &[&str]) -> Result<()> {
-    let owned = paths
-        .iter()
-        .map(|p| CString::new(p.as_bytes()))
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    let mut raw: Vec<*const std::ffi::c_char> = owned.iter().map(|s| s.as_ptr()).collect();
-    raw.push(std::ptr::null());
-    unsafe { gdal_sys::OSRSetPROJSearchPaths(raw.as_ptr()) };
-    Ok(())
-}
-
-/// The search path(s) PROJ currently uses, as GDAL sees them.
-///
-/// With nothing configured this reports the defaults PROJ was built with, which
-/// makes it the way to learn where the resource files actually live before
-/// overriding the paths.
-#[must_use]
-pub fn get_proj_search_paths() -> Vec<String> {
-    let list = unsafe { gdal_sys::OSRGetPROJSearchPaths() };
-    if list.is_null() {
-        return Vec::new();
-    }
-    let paths = _string_array(list);
-    unsafe { gdal_sys::CSLDestroy(list) };
-    paths
 }

--- a/src/vector/layer.rs
+++ b/src/vector/layer.rs
@@ -445,6 +445,34 @@ pub trait LayerAccess: Sized {
         }
     }
 
+    /// Select fields that the driver may omit while reading features.
+    ///
+    /// This wraps [`OGR_L_SetIgnoredFields`], which is already bound in
+    /// `gdal-sys` but has no safe wrapper here.  Field names are validated as C
+    /// strings and retained until the call returns; GDAL copies the
+    /// null-terminated list into the layer state.
+    ///
+    /// Use the special names `OGR_GEOMETRY` and `OGR_STYLE` to ignore those
+    /// pseudo-fields when the underlying driver supports it.
+    ///
+    /// [`OGR_L_SetIgnoredFields`]: https://gdal.org/api/vector_c_api.html#_CPPv423OGR_L_SetIgnoredFields9OGRLayerHPPKc
+    fn set_ignored_fields(&mut self, field_names: &[&str]) -> Result<()> {
+        let names = field_names
+            .iter()
+            .map(|name| CString::new(*name))
+            .collect::<std::result::Result<Vec<_>, NulError>>()?;
+        let mut pointers = names.iter().map(|name| name.as_ptr()).collect::<Vec<_>>();
+        pointers.push(std::ptr::null());
+        let rv = unsafe { gdal_sys::OGR_L_SetIgnoredFields(self.c_layer(), pointers.as_mut_ptr()) };
+        if rv != OGRErr::OGRERR_NONE {
+            return Err(GdalError::OgrError {
+                err: rv,
+                method_name: "OGR_L_SetIgnoredFields",
+            });
+        }
+        Ok(())
+    }
+
     /// Read batches of columnar [Arrow](https://arrow.apache.org/) data from OGR.
     ///
     /// Extended options are available via [`crate::cpl::CslStringList`].
@@ -746,6 +774,73 @@ mod tests {
     use crate::vector::FieldValue;
     use crate::{assert_almost_eq, Dataset, DriverManager, GdalOpenFlags};
     use gdal_sys::OGRwkbGeometryType;
+
+    /// Ignoring a field keeps it out of the features that are read.
+    ///
+    /// The assertion is on the *effect*, not on the call returning `Ok`: the
+    /// field is present before, absent while ignored, and present again once
+    /// the ignore list is cleared. Without the last step this would also pass
+    /// for a layer that had simply stopped returning that field.
+    ///
+    /// The fixture is built by the test rather than checked in, and it is a
+    /// GeoPackage on purpose: `SetIgnoredFields` is advisory, and drivers are
+    /// free to ignore it. The GeoJSON driver does exactly that - the same test
+    /// written against `roads.geojson` passes before the fix and after it, which
+    /// would have made it worthless.
+    #[test]
+    fn test_set_ignored_fields() -> Result<()> {
+        use std::fs;
+
+        let path = fixture("ignored_fields.gpkg");
+        let _ = fs::remove_file(&path);
+
+        {
+            let driver = DriverManager::get_driver_by_name("GPKG").unwrap();
+            let mut ds = driver.create_vector_only(&path).unwrap();
+            let layer = ds.create_layer(Default::default()).unwrap();
+            layer.create_defn_fields(&[
+                ("kept", OGRFieldType::OFTString),
+                ("ignored", OGRFieldType::OFTString),
+            ])?;
+            let mut feature = Feature::new(layer.defn())?;
+            feature.set_geometry(Geometry::from_wkt("POINT (1 2)")?)?;
+            feature.set_field_string(0, "here")?;
+            feature.set_field_string(1, "gone")?;
+            feature.create(&layer)?;
+        }
+
+        let ds = Dataset::open(&path).unwrap();
+        let mut layer = ds.layer(0).unwrap();
+
+        let read = |layer: &mut Layer<'_>, name: &str| {
+            let feature = layer.features().next().unwrap();
+            let idx = feature.field_index(name).unwrap();
+            feature.field(idx).unwrap()
+        };
+
+        assert!(read(&mut layer, "ignored").is_some());
+
+        layer.set_ignored_fields(&["ignored"])?;
+        layer.reset_feature_reading();
+        assert!(
+            read(&mut layer, "ignored").is_none(),
+            "an ignored field is not read"
+        );
+        assert!(
+            read(&mut layer, "kept").is_some(),
+            "the fields that were not ignored are still read"
+        );
+
+        // Clearing the list brings it back, which is what makes the assertion
+        // above about *this* field rather than about the layer.
+        layer.set_ignored_fields(&[])?;
+        layer.reset_feature_reading();
+        assert!(read(&mut layer, "ignored").is_some());
+
+        drop(ds);
+        fs::remove_file(&path).unwrap();
+        Ok(())
+    }
 
     fn ds_with_layer<F>(ds_name: &str, layer_name: &str, f: F)
     where


### PR DESCRIPTION
Two C functions that `gdal-sys` already binds have no safe wrapper in `gdal`. This adds them — **no new FFI**, the symbols are already in the pre-built bindings for every supported version.

## `Layer::set_ignored_fields`

Wraps `OGR_L_SetIgnoredFields`, which lets a driver skip columns it would otherwise read.

The test asserts the **effect** — the field is present, absent while ignored, and present again once the list is cleared — rather than the call returning `Ok`.

It builds a GeoPackage instead of using a checked-in fixture, and that choice is load-bearing: `SetIgnoredFields` is advisory and drivers may ignore it. The GeoJSON driver does. I wrote the test against `roads.geojson` first and it passed whether or not the wrapper did anything, which would have made it worthless.

## `set_proj_search_paths` / `get_proj_search_paths`

Wrap `OSRSetPROJSearchPaths` and `OSRGetPROJSearchPaths`.

These are not the same thing as setting the `PROJ_DATA` configuration option: GDAL does not forward that option to PROJ, so a relocatable distribution that only sets the option keeps reading whatever paths were compiled into PROJ at build time. That is the problem we hit, and this is what fixed it.

The getter matters on its own: with nothing configured it reports the defaults PROJ was built with, which is how you learn where the resource files actually live before overriding them.

The paths are process-global, so the test restores whatever it found and runs behind a mutex — two tests writing a global concurrently would make each other flaky rather than fail honestly.

## Provenance and testing

Both wrappers have been in use in production in [plenora-IO-tools](https://github.com/PlenoraETL/plenora-IO-tools), a GDAL-backed reader, for some months; this is the same code, ported to `master`.

Verified against GDAL 3.8.4 with the pre-built bindings (no `bindgen`): `cargo test -p gdal` passes — 281 / 1 / 1 / 57 — and clippy and `fmt --check` are clean.

One thing worth flagging: `get_proj_search_paths` needs `_string_array`, which `utils.rs` already exports but `srs.rs` did not import, so the `use` line grows by one name.

Happy to split this into two PRs if you'd rather review them separately — they're independent.